### PR TITLE
refactor paramviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Manifest.toml
 docs/build/
 docs/node_modules/
 docs/package-lock.json
+
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
+ClimaLand = "08f4d4ce-cf43-44bb-ad95-9d2d5f413532"
+ClimaParams = "5c42b081-d73a-476f-9059-fd94b934656c"
+ClimaViz = "396db26a-da9e-4cf0-936a-85fded5d16c1"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
+WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"

--- a/examples/paramviz/apps.jl
+++ b/examples/paramviz/apps.jl
@@ -1,5 +1,5 @@
 # Load packages
-using ParamViz
+using ClimaViz
 using Bonito
 using ClimaLand
 using ClimaLand.Canopy
@@ -7,7 +7,7 @@ using ClimaLand.Soil.Biogeochemistry
 import ClimaParams as CP
 import ClimaLand.Parameters as LP
 FT = Float64
-toml_dict = create_toml_dict(FT)
+toml_dict = LP.create_toml_dict(FT)
 earth_param_set = LP.LandParameters(toml_dict)
 RTparams = BeerLambertParameters(toml_dict)
 
@@ -21,16 +21,16 @@ server = Server(
 )
 
 # Load and create apps
-include("apps/leaf_an.jl");
+include("leaf_an.jl");
 An_app = An_app_f();
 An_app = An_app_f(); # need to run twice for unicode character... (bug)
-include("apps/beer.jl");
+include("beer.jl");
 beer_app = Beer_app_f();
 beer_app = Beer_app_f();
-include("apps/hetero_resp.jl");
+include("hetero_resp.jl");
 Rh_app = Rh_app_f();
 Rh_app = Rh_app_f();
-include("apps/leaf_an_ci.jl");
+include("leaf_an_ci.jl");
 An_ci_app = An_ci_app_f();
 An_ci_app = An_ci_app_f();
 

--- a/examples/paramviz/hetero_resp.jl
+++ b/examples/paramviz/hetero_resp.jl
@@ -1,6 +1,9 @@
 using Unitful: K, °C, mol, μmol, m, s, kg, J
+import ClimaParams as CP
+import ClimaLand.Parameters as LP
+FT = Float64
 
-function ParamViz.parameterisation(
+function ClimaViz.parameterisation(
     Tₛ,
     θ, # drivers
     ν,
@@ -11,30 +14,39 @@ function ParamViz.parameterisation(
     O₂_a,
     p_sx,
     Csom, # parameters
-    θ_a100,
     D_liq,
     D_oa,
+    R_gas,
 ) # constants
-    toml_dict = LP.create_toml_dict(FT)
-    params = SoilCO2ModelParameters(toml_dict; ν)
     # θ has to be lower than porosity
     if θ > ν
         θ = ν
     end
-
-    Rh = microbe_source(Tₛ, θ, Csom, params)
+    # O₂ availability (Millington-Quirk tortuosity)
+    θ_a = max(ν - θ, FT(0))
+    O2_avail = D_oa * O₂_a * θ_a^(FT(4 / 3))
+    # DAMM model (Dual Arrhenius Michaelis-Menten)
+    Vmax = α_sx * exp(-Ea_sx / (R_gas * Tₛ))
+    Sx = p_sx * Csom * D_liq * max(θ, FT(0))^3
+    MM_sx = Sx / (kM_sx + Sx)
+    MM_o2 = O2_avail / (kM_O₂ + O2_avail)
+    Rh = Vmax * MM_sx * MM_o2
     return Rh
 end
 
 function Rh_app_f()
+    toml_dict = LP.create_toml_dict(FT)
+    earth_param_set = LP.LandParameters(toml_dict)
+    R_gas = FT(LP.gas_constant(earth_param_set))
+
     drivers = Drivers(
         ("Tₛ (°C)", "θ (m³ m⁻³)"), # drivers.names
-        (FT.([273, 323]), FT.([0.0, 1.0])), # drivers.ranges 
+        (FT.([273, 323]), FT.([0.0, 1.0])), # drivers.ranges
         ((K, °C), (m^3 * m^-3, m^3 * m^-3)),
     )
 
     parameters = Parameters(
-        (# names   
+        (# names
             "Soil porosity, ν (m³ m⁻³)",
             "Pre-exponential factor, α_sx (kg C m⁻³ s⁻¹)",
             "Activation energy, Ea_sx (J mol⁻¹)",
@@ -49,8 +61,8 @@ function Rh_app_f()
             FT.([100e3, 300e3]), # α_sx
             FT.([50e3, 70e3]), # Ea_sx
             FT.([1e-10, 0.1]), # kM_sx
-            FT.([1e-10, 0.1]), # kM_o2
-            FT.([0.005, 0.5]), # O2_a
+            FT.([1e-10, 0.1]), # kM_O₂
+            FT.([0.005, 0.5]), # O₂_a
             FT.([0.005, 0.5]), # p_sx
             FT.([1.0, 10.0]), # Csom
         ),
@@ -59,8 +71,8 @@ function Rh_app_f()
             (kg * m^-3 * s^-1, kg * m^-3 * s^-1), # α_sx
             (J * mol^-1, J * mol^-1), # Ea_sx
             (kg * m^-3, kg * m^-3), # kM_sx
-            (m^3 * m^-3, m^3 * m^-3), # kM_O2
-            (m, m), # O2_a
+            (m^3 * m^-3, m^3 * m^-3), # kM_O₂
+            (m, m), # O₂_a
             (m, m), # p_sx
             (kg * m^-3, kg * m^-3), # Csom
         ),
@@ -68,25 +80,25 @@ function Rh_app_f()
 
     constants = Constants(
         (# names
-            "Air-filled porosity at soil water potential of -100 cm H₂O (~ 10 Pa)",
             "Diffusivity of soil C substrate in liquid (unitless)",
-            "Diffusion coefficient of oxygen in air, dimensionless",
+            "Diffusion coefficient of oxygen in air (unitless)",
+            "Universal gas constant (J mol⁻¹ K⁻¹)",
         ),
         (# values
-            FT(0.1816), # θ_a100
             FT(3.17), # D_liq
             FT(1.67), # D_oa
+            R_gas,
         ),
     )
 
     inputs = Inputs(drivers, parameters, constants)
 
     output = Output(
-        "Rh (mg C m⁻³ s⁻¹)", # name #NEED TO CONVERT THE UNIT
+        "Rh (mg C m⁻³ s⁻¹)", # name
         [0, 20 * 1e-6], # range
-        (mol * m^-2 * s^-1, μmol * m^-2 * s^-1), # unit from, unit to --> actually need to fix this, should be g to mg C m-3 s-1
+        (mol * m^-2 * s^-1, μmol * m^-2 * s^-1), # unit from, unit to
     )
 
-    Rh_app = webapp(ParamViz.parameterisation, inputs, output)
+    Rh_app = webapp(parameterisation, inputs, output)
     return Rh_app
 end

--- a/examples/paramviz/hetero_resp_local.jl
+++ b/examples/paramviz/hetero_resp_local.jl
@@ -1,0 +1,18 @@
+# Launch the heterotrophic respiration (DAMM) dashboard on localhost
+# Run with: julia --project=examples examples/paramviz/hetero_resp_local.jl
+
+using ClimaViz
+using Bonito
+using Unitful, UnitfulMoles
+
+include("hetero_resp.jl")
+
+Rh_app = Rh_app_f()
+Rh_app = Rh_app_f() # need to run twice for unicode character... (bug)
+
+server = Server("127.0.0.1", 9384)
+route!(server, "/" => Rh_app)
+
+println("Heterotrophic respiration dashboard running at http://127.0.0.1:9384")
+
+wait()

--- a/ext/ParamVizExt/ParamVizExt.jl
+++ b/ext/ParamVizExt/ParamVizExt.jl
@@ -1,5 +1,8 @@
 module ParamVizExt
 
+using ClimaViz: Drivers, Parameters, Constants, Inputs, Output
+import ClimaViz: parameterisation, webapp, param_dashboard
+
 using WGLMakie
 using Bonito
 using SparseArrays
@@ -16,4 +19,4 @@ function __init__()
     Unitful.register(ParamVizExt)
 end
 
-end 
+end

--- a/ext/ParamVizExt/generate_fig.jl
+++ b/ext/ParamVizExt/generate_fig.jl
@@ -1,5 +1,3 @@
-export param_dashboard, webapp
-
 """
     param_dashboard(parameterisation::Function, inputs::Inputs, sliders)
 

--- a/ext/ParamVizExt/struct_and_functions.jl
+++ b/ext/ParamVizExt/struct_and_functions.jl
@@ -1,75 +1,18 @@
-export Drivers, Parameters, Constants, Inputs, Output # struct
-export mat, d1_vec, d2_vec, parameterisation # functions
-
-"""
-  Drivers(names, ranges, units)
-
-A struct to store drivers names, ranges and units
-"""
-struct Drivers # Need 2 drivers always
-  names 
-  ranges
-  units
-end
-
-"""
-  Parameters(names, ranges, units)
-
-A struct to store parameters names, ranges and units
-"""
-struct Parameters
-  names
-  ranges
-  units
-end
-
-"""
-  Constant(names, values)
-
-A struct to store constants names and values
-"""
-struct Constants # should be able to be 0, or have a way to deal with 0
-  names
-  values
-end
-
-"""
-  Inputs(drivers, parameters, constants)
-
-A struct to store drivers, parameters and constants. 
-"""
-struct Inputs
-  drivers::Drivers
-  parameters::Parameters
-  constants::Constants
-end
-
-"""
-  Output(name, range, unit)
-
-A struct to store output name, range and unit.
-"""
-struct Output
-  name
-  range
-  unit
-end
-
 """
     mat(parameterisation::Function, inputs::Inputs, parameters, steps::Real)
 
-Evaluate the function parameterisation on grid values of drivers x and y. 
+Evaluate the function parameterisation on grid values of drivers x and y.
 Returns vectors x and y, and a matrix of function output at those points, FMatrix.
 """
 function mat(parameterisation::Function, inputs::Inputs, parameters, steps::Real)
-  # range from min to max for n steps (size = steps) 
-  x = collect(range(inputs.drivers.ranges[1][1], length=steps, stop=inputs.drivers.ranges[1][2]))   
-  y = collect(range(inputs.drivers.ranges[2][1], length=steps, stop=inputs.drivers.ranges[2][2])) 
+  # range from min to max for n steps (size = steps)
+  x = collect(range(inputs.drivers.ranges[1][1], length=steps, stop=inputs.drivers.ranges[1][2]))
+  y = collect(range(inputs.drivers.ranges[2][1], length=steps, stop=inputs.drivers.ranges[2][2]))
   # Grid (size = steps*steps)
-  X = repeat(1:steps, inner=steps)  
-  Y = repeat(1:steps, outer=steps) 
+  X = repeat(1:steps, inner=steps)
+  Y = repeat(1:steps, outer=steps)
   # Grid (size = steps*steps)
-  X2 = repeat(x, inner=steps)    
+  X2 = repeat(x, inner=steps)
   Y2 = repeat(y, outer=steps)
   # args for parameterisation
   drivers = [(X2[i], Y2[i]) for i in 1:steps*steps]
@@ -83,12 +26,12 @@ end
 """
     d1_vec(y, parameterisation::Function, inputs::Inputs, parameters, steps::Real)
 
-Evaluate the function parameterisation on a line of driver x, with constant y. 
+Evaluate the function parameterisation on a line of driver x, with constant y.
 """
-function d1_vec(y, parameterisation::Function, inputs::Inputs, parameters, steps::Real) 
+function d1_vec(y, parameterisation::Function, inputs::Inputs, parameters, steps::Real)
   x = collect(range(inputs.drivers.ranges[1][1], inputs.drivers.ranges[1][2], steps)) # min d1 to max d1, n steps
   y = repeat([y], steps)
-  drivers = [(x[i], y[i]) for i in 1:steps] 
+  drivers = [(x[i], y[i]) for i in 1:steps]
   parameters = repeat([parameters], steps)
   constants = repeat([inputs.constants.values], steps)
   vec = parameterisation.(drivers, parameters, constants)
@@ -103,7 +46,7 @@ Evaluate the function parameterisation on a line of driver y, with constant x.
 function d2_vec(x, parameterisation::Function, inputs::Inputs, parameters, steps::Real)
   y = collect(range(inputs.drivers.ranges[2][1], inputs.drivers.ranges[2][2], steps)) # min d2 to max d2, n steps
   x = repeat([x], steps)
-  drivers = [(x[i], y[i]) for i in 1:steps] 
+  drivers = [(x[i], y[i]) for i in 1:steps]
   parameters = repeat([parameters], steps)
   constants = repeat([inputs.constants.values], steps)
   vecM = parameterisation.(drivers, parameters, constants)
@@ -113,4 +56,3 @@ end
 function parameterisation(drivers, parameters, constants)
   return parameterisation((drivers..., parameters..., constants...)...)
 end
-

--- a/src/ClimaViz.jl
+++ b/src/ClimaViz.jl
@@ -14,7 +14,10 @@ include("figures.jl")
 include("events.jl")
 include("layout.jl")
 include("dashboard.jl")
+include("paramviz.jl")
 
 export dashboard
+export Drivers, Parameters, Constants, Inputs, Output
+export parameterisation, webapp, param_dashboard
 
 end # module ClimaViz

--- a/src/paramviz.jl
+++ b/src/paramviz.jl
@@ -1,0 +1,58 @@
+"""
+  Drivers(names, ranges, units)
+
+A struct to store drivers names, ranges and units
+"""
+struct Drivers
+  names
+  ranges
+  units
+end
+
+"""
+  Parameters(names, ranges, units)
+
+A struct to store parameters names, ranges and units
+"""
+struct Parameters
+  names
+  ranges
+  units
+end
+
+"""
+  Constants(names, values)
+
+A struct to store constants names and values
+"""
+struct Constants
+  names
+  values
+end
+
+"""
+  Inputs(drivers, parameters, constants)
+
+A struct to store drivers, parameters and constants.
+"""
+struct Inputs
+  drivers::Drivers
+  parameters::Parameters
+  constants::Constants
+end
+
+"""
+  Output(name, range, unit)
+
+A struct to store output name, range and unit.
+"""
+struct Output
+  name
+  range
+  unit
+end
+
+# Function stubs — methods are added by ParamVizExt
+function parameterisation end
+function webapp end
+function param_dashboard end


### PR DESCRIPTION
Refactor ParamVizExt: move types to main module and fix hetero_resp example
                                                                                                                               
Move ParamViz struct definitions (Drivers, Parameters, Constants, Inputs, Output) and function stubs (parameterisation, webapp, param_dashboard) from the extension into the main ClimaViz module so they are accessible via using ClimaViz. Update the hetero_resp example for the current ClimaLand API (5-arg microbe_source, removed ν from SoilCO2ModelParameters) by inlining the DAMM model. Add a localhost launcher script for the Rh dashboard.
