### PR TITLE
Coupled-mode dashboard, carbon & atmos benchmarks, model summary

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,3 +4,10 @@ git-tree-sha1 = "6cddb07eeee2dd46dc5a19e9b2f706302ddba2c9"
     [[era5_monthly_averages_surface_single_level_1979_2024.download]]
     sha256 = "46b422722d98c89c6bc0b8641bff259db1caee253f45389ddf9eb9c2d31ed605"
     url = "https://caltech.box.com/shared/static/jbgtyt6oq9lxvk8il5zzck6k581q7f3k.gz"
+
+[inversion_nee]
+git-tree-sha1 = "d400472ea191639cb1dafac41b09ce36383aee54"
+
+    [[inversion_nee.download]]
+    sha256 = "84ccc2b60b276575342886535d78faa83f64dd83e327f65b31a10da8f9da721c"
+    url = "https://caltech.box.com/shared/static/13xeg76obc5cc73h2sqzhogx0hr97poz.gz"

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### New Features
+
+#### ClimaCoupler (multi-component) outputs
+- `dashboard(path; coupled = true)` reads ClimaCoupler output directories
+  (`clima_atmos/`, `clima_land/`, `clima_ocean/`, `clima_seaice/` subfolders)
+  and adds a "Component:" menu to switch between them at runtime; empty or
+  missing components are skipped
+- The atmos component is restricted to its monthly (`_1M_`) native-grid
+  diagnostics; land files missing a `start_date` attribute inherit the atmos
+  start date
+- ERA5 surface-flux benchmarks registered under the ClimaAtmos/CMIP names
+  (`hfls`, `hfss`, `rlus`, `rsus`) in addition to the ClimaLand ones
+- "Global" statistics (global time series, metrics table, model summary)
+  follow the component's spatial mask: land mean (ocean-masked) for land and
+  plain ClimaLand runs as before, full globe for atmos, ocean mean
+  (land-masked) for ocean/seaice — menu labels and summary captions adapt
+
+#### Model performance summary
+- New "Model summary" button opens an overlay with the global ocean-masked
+  RMSE (and bias) of every benchmarked variable vs. observations over the
+  whole simulation period, per season (All-time / DJF / MAM / JJA / SON),
+  color-coded green→red by RMSE relative to the observed mean
+- Computed once per component and persisted in the `.climaviz_cache`, so
+  reopening is instant; `dashboard(...; precompute = true)` also warms it
+
+### Performance Improvements
+
+- Benchmark session caches (regridded obs slices, bias limits, per-frame
+  metrics) are now keyed by (variable, reduction, period, level) and kept for
+  the whole session instead of being discarded on every variable switch —
+  returning to an already-visited variable repaints instantly
+- Map colorbar limits (a full-field quantile scan) are cached per
+  (variable, reduction, period, level, height)
+- Scrubbing the time slider on un-precomputed data no longer blocks ~2 s per
+  tick: the per-frame metrics computation runs asynchronously and only the
+  newest result is applied (latest-wins), with results cached for revisits
+
 ## v0.1.4 - 2025-11-11
 
 ### New Features

--- a/Project.toml
+++ b/Project.toml
@@ -27,10 +27,11 @@ CliCalExt = ["EnsembleKalmanProcesses", "JLD2"]
 ParamVizExt = ["Unitful", "UnitfulMoles"]
 
 [extras]
+ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ClimaAnalysis", "Test"]
 
 [compat]
 Bonito = "4.1.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Dashboard" => "dashboard.md",
         "API Reference" => "api.md",
         "Extensions" => "extensions.md",
         "Examples" => "examples.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,6 +11,14 @@ dashboard
 precompute_dashboard_cache
 ```
 
+## Observation registries
+
+```@docs
+default_obs
+default_era5_obs
+default_inversion_obs
+```
+
 ## Index
 
 ```@index

--- a/docs/src/dashboard.md
+++ b/docs/src/dashboard.md
@@ -1,0 +1,164 @@
+# The Dashboard
+
+```@meta
+CurrentModule = ClimaViz
+```
+
+`dashboard(path)` launches an interactive web dashboard for exploring climate
+simulation outputs (anything readable by `ClimaAnalysis.SimDir`) and
+benchmarking them against gridded observations.
+
+## Quick start
+
+```julia
+using ClimaViz
+
+# A single output folder (e.g. a ClimaLand or ClimaAtmos run):
+dashboard("path/to/output/")
+
+# A ClimaCoupler run (clima_atmos/, clima_land/, … subfolders):
+dashboard("path/to/coupler_output/"; coupled = true)
+
+# On HPC, serve on 0.0.0.0:8080 for SSH port forwarding:
+dashboard("path/to/output/"; HPC = true)
+```
+
+Then open `http://localhost:8080/` in your browser (see
+[Using from HPC](@ref) for port forwarding).
+
+## What you see
+
+The dashboard is a single page with a menu column and four linked panels:
+
+- **2D map** of the selected variable. Click anywhere to select a location —
+  the time series and vertical profile follow.
+- **Bias map** (simulation − observation), shown whenever the selected
+  variable has a registered observation. The observation is regridded onto
+  the simulation grid; the colorbar is symmetric and stable across time.
+- **Time series** at the selected location (or a global mean, see below),
+  with the observation overlaid when available.
+- **Vertical profile** for variables with a height dimension; for 2D
+  variables this panel is replaced by a **benchmark metrics table**
+  (Sim mean, Obs mean, Bias, RMSE for the selected time frame).
+
+## The menus
+
+| Menu | What it does |
+|---|---|
+| **Component** | (coupled mode only) Switch between `atmos`, `land`, `ocean`, `seaice`. Components with no output are hidden. |
+| **Variable** | Searchable list of every variable found in the output. |
+| **Aggregation** | Re-bin the time axis on the fly: native resolution (e.g. Monthly), Seasonal, or Annual. |
+| **Time series** | `Local (click map)` — the clicked location — or a global mean. Clicking a map switches back to Local. |
+| **Time** | Slider through the (aggregated) time axis. The ▶ button animates it; the speed slider sets the frame delay. |
+| **Height** | Level selection for 3D variables. |
+| **Model summary** | Opens the model performance summary overlay (see below). |
+| **Dark Mode** | Toggles the page theme. |
+
+### Global means and spatial masks
+
+"Global" statistics — the global time series, the metrics table and the model
+summary — use an area-weighted mean restricted to where the component's
+fields are meaningful:
+
+| Component | Mask | Menu label |
+|---|---|---|
+| land (and plain single-folder runs) | ocean-masked (land only) | `Global (land mean)` |
+| atmos | none (full globe) | `Global` |
+| ocean / seaice | land-masked (ocean only) | `Global (ocean mean)` |
+
+## Benchmarks
+
+Variables with a registered observation get the bias map, the metrics table,
+an observation line in the time series, and a row in the model summary. The
+built-in registry ([`default_obs`](@ref)) covers:
+
+| Simulation variable | Observation product | Notes |
+|---|---|---|
+| `lhf`, `shf`, `lwu`, `swu` | ERA5 monthly surface fluxes | ClimaLand names |
+| `hfls`, `hfss`, `rlus`, `rsus` | ERA5 monthly surface fluxes | same fields, ClimaAtmos/CMIP names |
+| `nee` | CarbonTracker CT2022 | inversion-derived, 2002–2020 |
+| `gpp` | GOSIF-GPP v2 | |
+| `er` | CarbonTracker + GOSIF residual | |
+| `hr` | Hashimoto 2015 | |
+
+Carbon fluxes are displayed in `g C m^-2 day^-1` (converted from the model's
+`mol CO2 m^-2 s^-1`). All observation data ships as lazy artifacts — nothing
+to download manually.
+
+### Custom observations
+
+Pass your own registry via the `obs` keyword: a
+`Dict{String, Function}` mapping a simulation short name to a loader. Each
+loader receives the simulation's start date and returns a
+`ClimaAnalysis.OutputVar` (units must match the displayed simulation units).
+Set `attributes["obs_source"]` on the returned variable to control the
+product name shown in the legend, bias title and metrics table:
+
+```julia
+my_obs = Dict{String, Function}(
+    "ts" => start_date -> begin
+        var = ClimaAnalysis.OutputVar("my_obs_ts.nc", "ts")
+        var.attributes["obs_source"] = "MyProduct"
+        var
+    end,
+)
+dashboard(path; obs = merge(default_obs(), my_obs))
+```
+
+## Model summary
+
+The **Model summary** button opens an overlay with one row per benchmarked
+variable and one column per season (All-time / DJF / MAM / JJA / SON). Each
+cell shows the global RMSE (and bias) against the observation over the whole
+simulation period, color-coded by RMSE relative to the observed mean (green
+≤ 25 %, red ≥ 125 %) — the whole model's performance in one image.
+
+The summary is computed once per component and persisted in the cache;
+reopening it is instant. Start the server with `precompute = true` to warm it
+up front.
+
+## ClimaCoupler outputs (`coupled = true`)
+
+A ClimaCoupler run writes one diagnostics folder per component:
+
+```
+coupler_output/
+├── clima_atmos/    # *_1M_*.nc monthly diagnostics (+ restarts, configs)
+├── clima_land/
+├── clima_ocean/
+└── clima_seaice/
+```
+
+With `coupled = true` the dashboard discovers these folders and adds the
+Component menu. Details handled for you:
+
+- The atmos component is restricted to its monthly (`_1M_`) native-grid
+  diagnostics (instantaneous fields and pressure-level variants are skipped).
+- Components whose files lack a `start_date` attribute (possible for land)
+  inherit the atmos start date.
+- Each component gets its own benchmark cache and spatial mask.
+- All components are assumed to share the diagnostic lon/lat grid (which is
+  how ClimaCoupler writes them).
+
+## Performance and caching
+
+The slow part of benchmarking — regridding observations onto the simulation
+grid and computing ocean-masked metrics — is cached persistently in
+`<output>/.climaviz_cache/` (one per component in coupled mode). Raw
+simulation fields are always read lazily and are never cached.
+
+- First visit to a variable computes its benchmark in the background (a
+  progress bar shows the status); everything after that is instant, including
+  switching back to previously viewed variables within a session.
+- [`precompute_dashboard_cache`](@ref) warms every cacheable entry up front;
+  `dashboard(path; precompute = true)` does this (plus the model summary)
+  before serving. Recommended for long-lived deployments:
+
+```julia
+dashboard("path/to/output/"; HPC = true, precompute = true)
+```
+
+The cache is fingerprinted against the source NetCDF files (size + mtime), so
+regenerating the simulation output invalidates it automatically. It is safe
+to delete `.climaviz_cache/` at any time. If the output folder is a git
+repository, add `.climaviz_cache/` to its `.gitignore`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,9 @@ ClimaViz is a Julia package for generating web dashboards from climate simulatio
 
 ## Features
 
-- **Interactive web dashboards**: Generate web-based visualizations of your simulation outputs
+- **Interactive web dashboards**: Generate web-based visualizations of your simulation outputs (see [The Dashboard](@ref))
+- **Observation benchmarking**: Bias maps, metrics and a one-page model performance summary against ERA5, CarbonTracker, GOSIF and more (built-in artifacts)
+- **ClimaCoupler support**: Browse the atmos/land/ocean/seaice components of a coupled run from one dashboard (`coupled = true`)
 - **HPC support**: Run directly from HPC environments with SSH port forwarding
 - **Local development**: Test and visualize locally before deployment
 - **ParamViz**: Visualize climate parameterizations
@@ -51,7 +53,7 @@ Then run the Julia code as shown above and access the dashboard on your local br
 ## Table of Contents
 
 ```@contents
-Pages = ["index.md", "api.md", "extensions.md", "examples.md"]
+Pages = ["index.md", "dashboard.md", "api.md", "extensions.md", "examples.md"]
 Depth = 2
 ```
 

--- a/src/ClimaViz.jl
+++ b/src/ClimaViz.jl
@@ -13,6 +13,8 @@ using GeoMakie
 include("utils.jl")
 include("benchmark.jl")
 include("cache.jl")
+include("coupler.jl")
+include("summary.jl")
 include("figures.jl")
 include("events.jl")
 include("layout.jl")
@@ -21,6 +23,7 @@ include("paramviz.jl")
 
 export dashboard
 export precompute_dashboard_cache
+export default_obs, default_era5_obs, default_inversion_obs
 export Drivers, Parameters, Constants, Inputs, Output
 export parameterisation, webapp, param_dashboard, dashboard_paramviz
 

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -37,19 +37,32 @@ function _era5_loader(varname_era5, varname_sim; flip_sign = false)
             end
         end
         obs_var.attributes["short_name"] = varname_sim
+        obs_var.attributes["obs_source"] = "ERA5"
         return obs_var
     end
 end
 
 """
+    obs_source_name(obs)
+
+Display name of the observation product behind `obs` (an `OutputVar` or
+`nothing`), read from its `"obs_source"` attribute. The built-in loaders set it
+("ERA5", "CarbonTracker", "GOSIF", …); custom loaders without the attribute
+fall back to the generic `"obs"`.
+"""
+obs_source_name(obs) = isnothing(obs) ? "obs" : get(obs.attributes, "obs_source", "obs")
+
+"""
     default_era5_obs()
 
-Built-in `Dict{String, Function}` mapping ClimaLand simulation short names to
-ERA5 monthly observation loaders. Each loader takes a `start_date` and returns
-a `ClimaAnalysis.OutputVar` aligned to that origin.
+Built-in `Dict{String, Function}` mapping simulation short names to ERA5
+monthly observation loaders. Each loader takes a `start_date` and returns a
+`ClimaAnalysis.OutputVar` aligned to that origin.
 
-Covers: `lhf`, `shf`, `lwu`, `swu` (W m⁻², surface monthly, 1°×1°). Returns an
-empty Dict if the underlying artifact is unavailable.
+Covers the surface fluxes (W m⁻², monthly, 1°×1°) under both the ClimaLand
+names (`lhf`, `shf`, `lwu`, `swu`) and the ClimaAtmos/CMIP names (`hfls`,
+`hfss`, `rlus`, `rsus`) — the same ERA5 fields and sign conventions either
+way. Returns an empty Dict if the underlying artifact is unavailable.
 """
 function default_era5_obs()
     isnothing(_era5_monthly_nc_path()) && return Dict{String, Function}()
@@ -58,8 +71,134 @@ function default_era5_obs()
         "shf" => _era5_loader("msshf", "shf"; flip_sign = true),
         "lwu" => _era5_loader("msuwlwrf", "lwu"; flip_sign = false),
         "swu" => _era5_loader("msuwswrf", "swu"; flip_sign = false),
+        "hfls" => _era5_loader("mslhf", "hfls"; flip_sign = true),
+        "hfss" => _era5_loader("msshf", "hfss"; flip_sign = true),
+        "rlus" => _era5_loader("msuwlwrf", "rlus"; flip_sign = false),
+        "rsus" => _era5_loader("msuwswrf", "rsus"; flip_sign = false),
     )
 end
+
+# ─── Inversion-derived carbon observations ────────────────────────────────────
+#
+# Monthly 1°×1° carbon fluxes from the ClimaLand `inversion_nee` artifact
+# (`derived_nee_gpp_er_rh_2002_2020.nc`, 2002–2020): CarbonTracker CT2022 NEE,
+# GOSIF-GPP v2, residual ER (= NEE + GPP), and Hashimoto-2015 Rh. See ClimaLand's
+# `get_inversion_obs_var_dict` — this mirrors its loading, minus the calibration
+# unit string. The inversion products are natively g C m^-2 day^-1, which is also
+# the dashboard's display unit for carbon (see `to_display_units`), so the loaders
+# keep that unit and the sim side is converted to match. Sign conventions already
+# match the model (positive = source for nee/er/hr, positive = uptake for gpp), so
+# no flip is applied.
+
+# mol CO2 (1:1 with mol C) → g C, per molar mass of carbon, then per day.
+const _G_C_PER_MOL = 12.011
+const _SECONDS_PER_DAY = 86400.0
+
+# ─── Display-unit conversion ──────────────────────────────────────────────────
+#
+# ClimaLand stores carbon fluxes in mol CO2 m^-2 s^-1, where values are ~1e-6 and
+# the metrics table would render every cell as 0.00. For display we rescale them —
+# and only them — to the more legible g C m^-2 day^-1. Detection is by unit string
+# so every carbon flux (gpp/nee/er/hr/ra, with or without an observation) is
+# caught while energy (W m^-2) and water (kg m^-2 s^-1) fluxes pass through.
+
+const _CARBON_FLUX_UNITS = ("mol CO2 m^-2 s^-1", "mol CO2 m**-2 s**-1")
+const _DISPLAY_CARBON_UNITS = "g C m^-2 day^-1"
+
+is_carbon_flux(var) = ClimaAnalysis.units(var) in _CARBON_FLUX_UNITS
+
+"""
+    to_display_units(var)
+
+Convert a freshly-loaded simulation `OutputVar` to the units the dashboard
+displays. Currently this rescales carbon fluxes from `mol CO2 m^-2 s^-1` to
+`g C m^-2 day^-1` (× molar mass of C × seconds/day); all other variables are
+returned unchanged. Apply this once, at each point a sim variable is loaded, so
+the map, bias panel, time series, and metrics all share one consistent unit.
+"""
+function to_display_units(var)
+    is_carbon_flux(var) || return var
+    return ClimaAnalysis.convert_units(
+        var, _DISPLAY_CARBON_UNITS;
+        conversion_function = u -> u * _G_C_PER_MOL * _SECONDS_PER_DAY,
+    )
+end
+
+function _inversion_nc_path()
+    try
+        dir = artifact"inversion_nee"
+        return joinpath(dir, "derived_nee_gpp_er_rh_2002_2020.nc")
+    catch e
+        @warn "ClimaViz: inversion_nee artifact not available; carbon benchmark disabled" exception=(e, catch_backtrace())
+        return nothing
+    end
+end
+
+# Scale every time slice in place by `1 / daysinmonth(date)`, converting a
+# monthly *total* (… month⁻¹) to a daily *rate* (… day⁻¹). Mirrors ClimaLand's
+# `_monthly_total_to_daily_rate!`; uses actual days-in-month to avoid the ±5%
+# spurious seasonality a constant 30.44 would introduce.
+function _monthly_total_to_daily_rate!(var)
+    dates = ClimaAnalysis.dates(var)
+    factors = 1.0 ./ Float64.(Dates.daysinmonth.(dates))
+    t_idx = var.dim2index["time"]
+    shape = ntuple(d -> d == t_idx ? length(factors) : 1, ndims(var.data))
+    var.data .*= reshape(factors, shape)
+    return var
+end
+
+# Build a loader for one inversion carbon variable. `varname_obs` is the name in
+# the NetCDF file (`nee`/`gpp`/`er`/`rh`); `varname_sim` is the matching sim
+# short_name (`nee`/`gpp`/`er`/`hr`). `monthly_total = true` first rescales a
+# monthly total to a daily rate (nee/gpp/er); `rh` is already a daily rate.
+# `source` is the product display name shown in the UI (legend, bias title, …).
+function _inversion_loader(varname_obs, varname_sim; monthly_total::Bool, source::String)
+    return function (_start_date)
+        path = _inversion_nc_path()
+        isnothing(path) && return nothing
+        obs_var = ClimaAnalysis.OutputVar(path, varname_obs)
+        obs_var = ClimaAnalysis.replace(obs_var, missing => NaN)
+        # → g C m⁻² day⁻¹ (the dashboard display unit; sim is converted to match)
+        monthly_total && _monthly_total_to_daily_rate!(obs_var)
+        obs_var = ClimaAnalysis.set_units(obs_var, _DISPLAY_CARBON_UNITS)
+        obs_var.attributes["short_name"] = varname_sim
+        obs_var.attributes["obs_source"] = source
+        return obs_var
+    end
+end
+
+"""
+    default_inversion_obs()
+
+Built-in `Dict{String, Function}` mapping ClimaLand carbon short names to
+inversion-derived observation loaders from the `inversion_nee` artifact. Each
+loader returns a `ClimaAnalysis.OutputVar` in `g C m⁻² day⁻¹` (the dashboard's
+carbon display unit), monthly 1°×1°, 2002–2020.
+
+Covers: `nee` (CarbonTracker CT2022), `gpp` (GOSIF-GPP v2), `er` (residual
+NEE + GPP), `hr` (Hashimoto-2015 Rh). Returns an empty Dict if the underlying
+artifact is unavailable.
+"""
+function default_inversion_obs()
+    isnothing(_inversion_nc_path()) && return Dict{String, Function}()
+    return Dict{String, Function}(
+        "nee" => _inversion_loader("nee", "nee"; monthly_total = true, source = "CarbonTracker"),
+        "gpp" => _inversion_loader("gpp", "gpp"; monthly_total = true, source = "GOSIF"),
+        "er"  => _inversion_loader("er", "er"; monthly_total = true, source = "CarbonTracker+GOSIF"),
+        "hr"  => _inversion_loader("rh", "hr"; monthly_total = false, source = "Hashimoto2015"),
+    )
+end
+
+"""
+    default_obs()
+
+Combined built-in observation set: ERA5 monthly energy fluxes
+([`default_era5_obs`](@ref): `lhf`, `shf`, `lwu`, `swu`) merged with the
+inversion-derived carbon fluxes ([`default_inversion_obs`](@ref): `nee`, `gpp`,
+`er`, `hr`). This is the default observation registry for [`dashboard`](@ref)
+and [`precompute_dashboard_cache`](@ref).
+"""
+default_obs() = merge(default_era5_obs(), default_inversion_obs())
 
 mutable struct ObsBundle
     loaders::Dict{String, Function}
@@ -292,12 +431,16 @@ Base.setindex!(t::MetricsTable, v, m::Symbol, s::Symbol) =
 function format_cell(t::MetricsTable, m::Symbol, s::Symbol)
     v = t[m, s]
     isnan(v) && return "—"
-    if m === :spatial_r || m === :amplitude_ratio
-        return string(round(v; digits = 2))
-    elseif m === :phase_shift
+    if m === :phase_shift
         return string(round(Int, v))
-    else
+    elseif m === :spatial_r || m === :amplitude_ratio
         return string(round(v; digits = 2))
+    elseif v == 0 || abs(v) >= 0.1
+        return string(round(v; digits = 2))
+    else
+        # Small magnitudes (e.g. a near-zero NEE bias) would round to 0.00 at two
+        # decimals; fall back to significant figures so they stay legible.
+        return string(round(v; sigdigits = 3))
     end
 end
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -182,14 +182,16 @@ function _start_date_of(var)
 end
 
 """
-    compute_benchmark_entry(sim_agg, obs_agg, fingerprint) -> BenchmarkCacheEntry
+    compute_benchmark_entry(sim_agg, obs_agg, fingerprint; mask = apply_oceanmask) -> BenchmarkCacheEntry
 
 Do the heavy benchmark work for one already-aggregated (sim, obs) pair: regrid
 every obs slice onto the sim grid, derive the bias-map colorbar limits, and
 compute the `:selected`-scope metrics for each time index. `obs_agg` must be the
-obs windowed/aligned to `sim_agg` (see `aggregate_obs`).
+obs windowed/aligned to `sim_agg` (see `aggregate_obs`). `mask` is the spatial
+mask used for the metrics (see `MASK_SPECS`); the caller must bake the matching
+`cache_tag` into `fingerprint` so mask changes invalidate the entry.
 """
-function compute_benchmark_entry(sim_agg, obs_agg, fingerprint::AbstractString)
+function compute_benchmark_entry(sim_agg, obs_agg, fingerprint::AbstractString; mask = ClimaAnalysis.apply_oceanmask)
     sim_dates = ClimaAnalysis.dates(sim_agg)
     obs_dates = ClimaAnalysis.dates(obs_agg)
     n = min(length(sim_dates), length(obs_dates))
@@ -215,7 +217,7 @@ function compute_benchmark_entry(sim_agg, obs_agg, fingerprint::AbstractString)
     for t in 1:n
         mt = compute_metrics(
             sim_trunc, obs_trunc;
-            selected_idx = t, scopes = (:selected,),
+            selected_idx = t, mask = mask, scopes = (:selected,),
             compute_seasonal_diagnostics = false,
         )
         metrics_per_t[t] = copy(mt.values)
@@ -231,12 +233,16 @@ end
 # ─── Batch precompute ─────────────────────────────────────────────────────────
 
 """
-    precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = true)
+    precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = true, mask_kind = :land)
 
 Warm the persistent benchmark cache for every (variable, reduction, period,
 aggregation level) in `path` that has a registered observation. Already-cached,
 up-to-date entries are skipped (cheap fingerprint check), so this is safe to
 re-run — e.g. after regenerating the longrun, or on each server restart.
+
+`mask_kind` selects the spatial mask for the metrics (see `MASK_SPECS`):
+`:land` (ocean-masked, the default), `:globe` (atmos components of coupled
+runs) or `:ocean`. It must match what the dashboard will use for this output.
 
 Run this once after producing the simulation output (or in CI). The dashboard
 reads whatever is present and falls back to live computation on a miss, so
@@ -244,7 +250,7 @@ precomputing is purely a responsiveness optimization.
 
 Returns the `BenchmarkCache`.
 """
-function precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = true)
+function precompute_dashboard_cache(path; obs = default_obs(), verbose = true, mask_kind::Symbol = :land)
     simdir = ClimaAnalysis.SimDir(path)
     cache = BenchmarkCache(path; enabled = true)
     if isnothing(cache.dir)
@@ -258,7 +264,7 @@ function precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = tr
         for reduction in keys(simdir.vars[short_name])
             for period in keys(simdir.vars[short_name][reduction])
                 var = try
-                    get(simdir; short_name = short_name, reduction = reduction, period = period)
+                    to_display_units(get(simdir; short_name = short_name, reduction = reduction, period = period))
                 catch e
                     @warn "ClimaViz: skip $short_name/$reduction/$period (load failed)" exception = e
                     continue
@@ -267,7 +273,8 @@ function precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = tr
                 bundle = ObsBundle(obs; start_date = _start_date_of(var))
                 o = get_obs(bundle, short_name)
                 isnothing(o) && continue
-                fingerprint = _source_fingerprint(simdir, short_name, reduction, period)
+                fingerprint = _source_fingerprint(simdir, short_name, reduction, period) *
+                    mask_spec(mask_kind).cache_tag
                 for level in available_levels(var)
                     key = (short_name, reduction, period, level)
                     if !isnothing(get_cached_entry(cache, key, fingerprint))
@@ -278,7 +285,7 @@ function precompute_dashboard_cache(path; obs = default_era5_obs(), verbose = tr
                     obs_agg = aggregate_obs(o, var, level)
                     isnothing(obs_agg) && continue
                     sim_agg = aggregate_var(var, level)
-                    entry = compute_benchmark_entry(sim_agg, obs_agg, fingerprint)
+                    entry = compute_benchmark_entry(sim_agg, obs_agg, fingerprint; mask = mask_spec(mask_kind).mask)
                     put_cached_entry!(cache, key, entry)
                     n_done += 1
                     verbose && @info "  cached" var = short_name reduction period level n = entry.n

--- a/src/coupler.jl
+++ b/src/coupler.jl
@@ -1,0 +1,95 @@
+# ─── ClimaCoupler multi-component outputs ────────────────────────────────────
+#
+# A ClimaCoupler run writes one diagnostics folder per component instead of a
+# single flat output directory:
+#
+#   <run>/clima_atmos/   <run>/clima_land/   <run>/clima_ocean/   <run>/clima_seaice/
+#
+# `dashboard(path; coupled = true)` discovers these, builds one `SimDir` per
+# non-empty component, and adds a "Component:" menu that swaps the active
+# `SimDir` (and its per-component benchmark cache) at runtime. All components
+# are assumed to share the same diagnostic lon/lat grid — ClimaCoupler regrids
+# every component's diagnostics onto one grid, and the dashboard's figures are
+# built against a single grid.
+
+const COUPLER_COMPONENTS = (
+    "atmos" => "clima_atmos",
+    "land" => "clima_land",
+    "ocean" => "clima_ocean",
+    "seaice" => "clima_seaice",
+)
+
+# Restrict an atmos SimDir to the monthly ("1M") diagnostics on the native
+# grid. The atmos folder also holds instantaneous fields (`orog_inst.nc`),
+# restart HDF5s, and `*_1M_average_pressure.nc` variants (the same field on
+# pressure levels); the latter make `get(simdir; short_name, reduction,
+# period)` ambiguous ("Found multiple coordinates"), so only the
+# `coord_type === nothing` (native) entries are kept. Mutates and returns
+# `simdir`.
+function _prune_to_1M!(simdir)
+    for store in (simdir.vars, simdir.variable_paths)
+        for short_name in collect(keys(store))
+            by_reduction = store[short_name]
+            for reduction in collect(keys(by_reduction))
+                by_period = by_reduction[reduction]
+                for period in collect(keys(by_period))
+                    if period != "1M"
+                        delete!(by_period, period)
+                        continue
+                    end
+                    by_coord = by_period[period]
+                    for coord in collect(keys(by_coord))
+                        isnothing(coord) || delete!(by_coord, coord)
+                    end
+                    isempty(by_coord) && delete!(by_period, period)
+                end
+                isempty(by_period) && delete!(by_reduction, reduction)
+            end
+            isempty(by_reduction) && delete!(store, short_name)
+        end
+    end
+    return simdir
+end
+
+"""
+    discover_components(path)
+
+Scan a ClimaCoupler output directory for component subfolders
+(`clima_atmos`, `clima_land`, `clima_ocean`, `clima_seaice`) and return a
+`Vector` of `(label = "atmos", path = …, simdir = SimDir(…))` NamedTuples for
+every component that contains at least one readable variable. The atmos
+component is pruned to its monthly (`_1M_`) native-grid diagnostics (see
+`_prune_to_1M!`); empty folders (e.g. an inactive ocean) are skipped.
+"""
+function discover_components(path)
+    components = NamedTuple{(:label, :path, :simdir), Tuple{String, String, Any}}[]
+    for (label, subdir) in COUPLER_COMPONENTS
+        component_path = joinpath(path, subdir)
+        isdir(component_path) || continue
+        simdir = try
+            ClimaAnalysis.SimDir(component_path)
+        catch e
+            @warn "ClimaViz: failed to read coupler component" component_path exception = e
+            continue
+        end
+        label == "atmos" && _prune_to_1M!(simdir)
+        isempty(simdir.vars) && continue
+        push!(components, (label = label, path = component_path, simdir = simdir))
+    end
+    return components
+end
+
+# The run's start_date as an ISO string, read from the first variable of
+# `simdir` (atmos in practice). Used to patch components whose NetCDF files
+# lack the attribute (possible for land). Returns `nothing` if unavailable.
+function _component_start_date(simdir)
+    isempty(simdir.vars) && return nothing
+    short_name = first(_sorted_vars(simdir))
+    var = try
+        get(simdir; short_name = short_name)
+    catch e
+        @warn "ClimaViz: could not load $short_name to read start_date" exception = e
+        return nothing
+    end
+    return Base.get(var.attributes, "start_date", nothing)
+end

--- a/src/dashboard.jl
+++ b/src/dashboard.jl
@@ -1,5 +1,10 @@
+# Internal test/debug hook: when set, called with the live widget bundle at the
+# end of each dashboard session setup so integration tests can drive the menus
+# server-side. Stays `nothing` in normal use.
+const _DASHBOARD_HOOK = Ref{Any}(nothing)
+
 """
-    dashboard(path::String; HPC=false, obs=default_era5_obs())
+    dashboard(path::String; HPC=false, obs=default_obs())
 
 Launch an interactive web dashboard for visualizing climate simulation outputs
 and benchmarking against gridded observations when available.
@@ -11,20 +16,28 @@ Features:
   native data resolution.
 - 2D map (model) with click-to-select location.
 - Bias map (model − observation) when an observation is registered for the
-  selected variable; otherwise hidden.
+  selected variable; otherwise hidden. Observation products are shown by name
+  (ERA5, CarbonTracker, GOSIF, …) in the legend, bias panel and metrics table.
+- Time-series mode menu: Local (the clicked map location) or Global (area-
+  weighted mean, the same convention as the metrics table). The spatial mask
+  for "global" follows the component: ocean-masked land mean for ClimaLand
+  output (and plain runs), the full globe for atmos, land-masked ocean mean
+  for ocean/seaice. Clicking a map switches back to Local at that location.
 - Vertical profile when the variable has a `z` / `z_reference` dimension;
   otherwise replaced by a benchmark metrics table (Sim mean, Obs mean, Bias,
   RMSE, Spatial r, Amplitude ratio, Phase shift across All-time / Selected /
   DJF / MAM / JJA / SON).
-- Time-series at the selected location.
+- Time-series at the selected location (or global land mean), with the
+  observation overlaid when available.
 
 # Arguments
 - `path::String`: simulation output directory (readable by `SimDir`).
 - `HPC::Bool = false`: serve on `0.0.0.0:8080` for HPC port-forwarding.
-- `obs::Dict{String,Function} = default_era5_obs()`: maps variable short_names
+- `obs::Dict{String,Function} = default_obs()`: maps variable short_names
   to obs loaders. Each loader receives the sim's start_date and returns a
   `ClimaAnalysis.OutputVar`. The default registers ERA5 monthly fluxes for
-  `lhf`, `shf`, `lwu`, `swu` via the ClimaViz LazyArtifact.
+  `lhf`, `shf`, `lwu`, `swu` and inversion-derived carbon fluxes for `nee`,
+  `gpp`, `er`, `hr` via ClimaViz LazyArtifacts.
 - `cache::Bool = true`: read/write the persistent benchmark cache in
   `<path>/.climaviz_cache`. On a hit, the bias map, colorbar limits and metrics
   for the selected variable are served from disk instead of recomputed
@@ -33,9 +46,27 @@ Features:
   miss, so this is purely a responsiveness optimization. See
   [`precompute_dashboard_cache`](@ref) to warm it up front.
 - `precompute::Bool = false`: before serving, run
-  [`precompute_dashboard_cache`](@ref) to warm every cacheable entry. Slow on a
-  cold cache (regridding + metrics for all variables), near-instant if already
-  warm. Useful for long-lived deployments; ignored when `cache = false`.
+  [`precompute_dashboard_cache`](@ref) (per component in coupled mode) and warm
+  the model-summary cache, so every benchmark panel and the first "Model
+  summary" click are instant. Slow on a cold cache (regridding + metrics for
+  all variables), near-instant if already warm. Useful for long-lived
+  deployments; ignored when `cache = false`.
+- `run_title::String = ""`: optional caption shown in the menu, just below the
+  play button (e.g. `"ClimaLand long run, #4836"`). Empty string hides it.
+- `coupled::Bool = false`: treat `path` as a ClimaCoupler output directory
+  holding one subfolder per component (`clima_atmos`, `clima_land`,
+  `clima_ocean`, `clima_seaice`) instead of a single flat output. Adds a
+  "Component:" menu that swaps the active component at runtime; components
+  whose folder is missing or empty are skipped. The atmos component is
+  restricted to its monthly (`_1M_`) native-grid diagnostics, and components
+  whose files lack a `start_date` attribute (possible for land) inherit the
+  atmos one. All components are assumed to share the diagnostic lon/lat grid
+  (ClimaCoupler regrids them onto one). The benchmark cache lives per
+  component folder.
+
+A "Model summary" button opens an overlay with the global RMSE (and bias) of
+every benchmarked variable over the whole simulation period, per season —
+computed once per component (persisted via the cache) on first open.
 
 # Example
 ```julia
@@ -45,16 +76,58 @@ dashboard("path/to/output/")
 # Warm the cache once, then everything is instant:
 precompute_dashboard_cache("path/to/output/")
 dashboard("path/to/output/")
+
+# ClimaCoupler AMIP run (clima_atmos/, clima_land/, … subfolders):
+dashboard("path/to/coupler_output/"; coupled = true)
 ```
 """
-function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, precompute = false)
-    bench_cache = cache ? BenchmarkCache(path) : nothing
-    if precompute && cache
-        precompute_dashboard_cache(path; obs = obs)
+function dashboard(path; HPC = false, obs = default_obs(), cache = true, precompute = false, run_title = "", coupled = false)
+    if coupled
+        components_found = discover_components(path)
+        isempty(components_found) && error(
+            "ClimaViz: no ClimaCoupler component output found under $path " *
+            "(expected non-empty clima_atmos/, clima_land/, … subfolders)",
+        )
+        components = Dict(
+            c.label => (simdir = c.simdir, bench_cache = cache ? BenchmarkCache(c.path) : nothing)
+            for c in components_found
+        )
+        component_labels = [c.label for c in components_found]
+        coupled_fallback_start_date = "atmos" in component_labels ?
+            _component_start_date(components["atmos"].simdir) : nothing
+        if precompute && cache
+            for c in components_found
+                kind = component_mask_kind(c.label)
+                precompute_dashboard_cache(c.path; obs = obs, mask_kind = kind)
+                precompute_summary!(
+                    c.simdir, components[c.label].bench_cache, obs;
+                    fallback_start_date = coupled_fallback_start_date, mask_kind = kind,
+                )
+            end
+        end
+    else
+        single_bench_cache = cache ? BenchmarkCache(path) : nothing
+        if precompute && cache
+            precompute_dashboard_cache(path; obs = obs)
+            precompute_summary!(ClimaAnalysis.SimDir(path), single_bench_cache, obs)
+        end
     end
     app = Bonito.App(title = "CliMA dashboard") do session
-        simdir = ClimaAnalysis.SimDir(path)
-        vars = collect(keys(simdir.vars))
+        if coupled
+            initial_component = first(component_labels)
+            simdir = components[initial_component].simdir
+            bench_cache = components[initial_component].bench_cache
+            # Components without their own start_date (possible for land)
+            # inherit the atmos one.
+            fallback_start_date = coupled_fallback_start_date
+            mask_kind = component_mask_kind(initial_component)
+        else
+            simdir = ClimaAnalysis.SimDir(path)
+            bench_cache = single_bench_cache
+            fallback_start_date = nothing
+            mask_kind = :land
+        end
+        vars = _sorted_vars(simdir)
 
         # Dark mode (default on)
         checkbox_style = Bonito.Styles(
@@ -79,6 +152,16 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
             "min-width" => "80px", "max-width" => "180px",
         )
 
+        # Component (coupled mode only)
+        if coupled
+            component_menu = Bonito.Dropdown(component_labels; style = dropdown_style)
+            component_menu.value[] = initial_component
+            component_label = component_menu.value
+        else
+            component_menu = nothing
+            component_label = Observable("")
+        end
+
         # Variable / reduction / period
         var_menu = Bonito.ChoicesBox(vars; style = var_menu_style)
         var_menu.value[] = first(vars)
@@ -93,7 +176,7 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         period_menu.value[] = first(available_periods)
 
         # Initial variable
-        initial_var = get(simdir; short_name = var_selected[], reduction = reduction_menu.value[], period = period_menu.value[])
+        initial_var = load_sim_var(simdir, var_selected[], reduction_menu.value[], period_menu.value[]; fallback_start_date)
         lon = initial_var.dims["lon"]
         lat = initial_var.dims["lat"]
         times = initial_var.dims["time"]
@@ -105,6 +188,11 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         aggregation_menu = Bonito.Dropdown(agg_labels; style = dropdown_style)
         aggregation_menu.value[] = first(agg_labels)
         aggregation_level = Observable(:native)
+
+        # Time-series mode: local (clicked point) or global mean (the label
+        # and mask follow the component — land mean / full globe / ocean mean)
+        ts_mode_menu = Bonito.Dropdown(ts_mode_labels(mask_kind); style = dropdown_style)
+        timeseries_mode = Observable(:local)
 
         # Observable for the current variable + aggregated form. Use Any-typed
         # observables because we swap between 3D and 4D OutputVars at runtime.
@@ -122,6 +210,7 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         initial_obs_agg = aggregate_obs(initial_obs, initial_var, :native)
         obs_agg = Observable{Any}(initial_obs_agg)
         show_bias = Observable(!isnothing(initial_obs_agg) && _has_lonlat_only(initial_var))
+        obs_name = Observable(obs_source_name(isnothing(initial_obs_agg) ? initial_obs : initial_obs_agg))
 
         # Sliders
         time_slider = Bonito.StylableSlider(1:length(times))
@@ -168,7 +257,7 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         # Bias observables
         bias_sliced = Observable(fill(NaN, length(lon), length(lat)))
         bias_limits = Observable((-1.0, 1.0))
-        bias_title = Observable(show_bias[] ? bias_title_string(initial_var, dates_array, time_selected[], aggregation_level[]) : "no observation available")
+        bias_title = Observable(show_bias[] ? bias_title_string(initial_var, dates_array, time_selected[], aggregation_level[], obs_name[]) : "no observation available")
 
         # Metrics observable + scope dropdown selection
         metrics = Observable(MetricsTable(ClimaAnalysis.units(initial_var)))
@@ -208,7 +297,7 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
             create_main_figure(var, var_sliced, limits, lon, lat, lon_profile, lat_profile, :black, earth_img)
 
         fig_bias, ax_bias, coastlines_plot_bias, cbar_bias, surface_plot_bias, colorbar_label_bias =
-            create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat, lon_profile, lat_profile, :black)
+            create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat, lon_profile, lat_profile, :black, obs_name)
 
         fig_profile, ax_profile, profile_xlabel, profile_lines, profile_hlines, heights_obs, profile_box =
             create_profile_figure(var, heights, profile, profile_limits, current_height, profile_title, time_selected, :black, show_height)
@@ -222,15 +311,17 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         end
 
         fig_timeseries, ax_timeseries, timeseries_ylabel, current_time_index, n_ticks,
-            timeseries_lines, timeseries_obs_lines, timeseries_legend =
+            timeseries_lines, timeseries_obs_lines =
             create_timeseries_figure(
                 var, dates_array, timeseries, timeseries_obs, show_obs_line,
                 timeseries_title, time_selected, :black,
             )
 
-        bias_limits_cache = Dict{Tuple{String, Symbol}, Tuple{Float64, Float64}}()
-        obs_resampled_cache = Dict{Tuple{String, Symbol}, Any}()
-        metrics_cache = Dict{Tuple{String, Symbol, Int}, Any}()
+        bias_limits_cache = Dict{Tuple{String, String, String, Symbol}, Tuple{Float64, Float64}}()
+        obs_resampled_cache = Dict{Tuple{String, String, String, Symbol}, Any}()
+        metrics_cache = Dict{Tuple{String, String, String, Symbol, Int}, Any}()
+        limits_cache = Dict{Tuple{String, String, String, Symbol, Int}, Tuple{Float64, Float64}}()
+        limits_cache[(ClimaAnalysis.short_name(initial_var), reduction_menu.value[], period_menu.value[], :native, height_selected[])] = limits[]
 
         state = AppState(
             simdir, var, obs_bundle, dates_array, collect(heights), times,
@@ -240,20 +331,20 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
             metrics, metrics_scope,
             lon_profile, lat_profile, profile, profile_limits, current_height, profile_title, profile_xlabel,
             heights_obs,
-            timeseries, timeseries_obs, show_obs_line, timeseries_title, timeseries_ylabel, current_time_index,
+            timeseries, timeseries_obs, show_obs_line, timeseries_mode, obs_name, timeseries_title, timeseries_ylabel, current_time_index,
             time_selected, height_selected, speed_selected,
             time_value_text, height_value_text, speed_value_text,
             dark_mode, show_height, is_playing, is_loading, loading_status,
             ax, ax_bias, ax_profile, ax_timeseries,
-            profile_lines, profile_hlines, timeseries_lines, timeseries_obs_lines, timeseries_legend,
+            profile_lines, profile_hlines, timeseries_lines, timeseries_obs_lines, nothing,  # legend built below
             coastlines_plot, coastlines_plot_bias,
             cbar, cbar_bias, colorbar_label, colorbar_label_bias,
             profile_box, surface_plot_colormap, surface_plot_bias,
             earth_surface, earth_img,
             lon, lat,
             fig, fig_bias, fig_profile, fig_timeseries,
-            bias_limits_cache, obs_resampled_cache, metrics_cache,
-            bench_cache, reduction_menu.value[], period_menu.value[],
+            bias_limits_cache, obs_resampled_cache, metrics_cache, limits_cache,
+            bench_cache, reduction_menu.value[], period_menu.value[], fallback_start_date, mask_kind,
             n_ticks, false,
         )
 
@@ -263,12 +354,18 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
             update_title(state, time_selected[])
         end
 
+        # Model summary button + modal overlay
+        summary_button, summary_overlay, show_summary, summary_content = summary_ui(component_label)
+
         # Wire up handlers
-        setup_mouse_click_handler(fig, state)
+        coupled && setup_component_handler(component_menu, var_menu, ts_mode_menu, state, components)
+        setup_summary_handler(summary_button, show_summary, summary_content, state, component_label)
+        setup_mouse_click_handler(fig, state, ts_mode_menu)
         setup_variable_handler(var_menu, reduction_menu, period_menu, height_slider, time_slider, aggregation_menu, state)
         setup_reduction_handler(reduction_menu, period_menu, time_slider, aggregation_menu, state)
         setup_period_handler(period_menu, reduction_menu, time_slider, aggregation_menu, state)
         setup_aggregation_handler(aggregation_menu, time_slider, state)
+        setup_timeseries_mode_handler(ts_mode_menu, state)
         setup_time_handler(time_slider, state)
         setup_height_handler(height_slider, state)
         setup_speed_handler(speed_slider, state)
@@ -288,50 +385,29 @@ function dashboard(path; HPC = false, obs = default_era5_obs(), cache = true, pr
         # Initial benchmark computation
         recompute_benchmark!(state)
 
-        # Initial dark-mode (start dark) styling on Makie side
-        ax.titlecolor = :white
-        coastlines_plot.color = :white
-        cbar.labelcolor = :white
-        cbar.ticklabelcolor = :white
-        ax_bias.titlecolor = :white
-        coastlines_plot_bias.color = :white
-        cbar_bias.labelcolor = :white
-        cbar_bias.ticklabelcolor = :white
-        ax_profile.backgroundcolor = :black
-        ax_profile.titlecolor = :white
-        ax_profile.xlabelcolor = :white
-        ax_profile.ylabelcolor = :white
-        ax_profile.xticklabelcolor = :white
-        ax_profile.yticklabelcolor = :white
-        profile_lines.color = :white
-        profile_box.color = :black
-        ax_timeseries.backgroundcolor = :black
-        ax_timeseries.titlecolor = :white
-        ax_timeseries.xlabelcolor = :white
-        ax_timeseries.ylabelcolor = :white
-        ax_timeseries.xticklabelcolor = :white
-        ax_timeseries.yticklabelcolor = :white
-        ax_timeseries.xtickcolor = :white
-        ax_timeseries.ytickcolor = :white
-        ax_timeseries.leftspinecolor = :white
-        ax_timeseries.rightspinecolor = :white
-        ax_timeseries.topspinecolor = :white
-        ax_timeseries.bottomspinecolor = :white
-        ax_timeseries.xgridcolor = (:white, 0.2)
-        ax_timeseries.ygridcolor = (:white, 0.2)
-        timeseries_lines.color = :white
-        timeseries_legend.labelcolor = :white
-
+        # Build the time-series legend (model + obs product name), then apply
+        # the initial dark-mode styling — the dark_mode handler covers every
+        # Makie element, so one notify suffices.
+        _refresh_timeseries_legend!(state)
         notify(dark_mode)
 
+        isnothing(_DASHBOARD_HOOK[]) || _DASHBOARD_HOOK[]((;
+            state, var_menu, component_menu, reduction_menu, period_menu,
+            aggregation_menu, ts_mode_menu, time_slider, summary_button, show_summary, summary_content,
+        ))
+
         return layout(
-            var_menu, reduction_menu, period_menu, aggregation_menu,
+            var_menu, reduction_menu, period_menu, aggregation_menu, ts_mode_menu,
             time_slider, height_slider, play_button, speed_slider,
             fig, fig_bias, fig_profile, fig_timeseries,
             show_height, show_bias, metrics, time_value_text,
             time_value_label, height_value_label, speed_value_label,
             dark_mode_checkbox,
-            is_loading, loading_status,
+            is_loading, loading_status, obs_name;
+            run_title = run_title,
+            component_menu = component_menu,
+            summary_button = summary_button,
+            summary_overlay = summary_overlay,
         )
     end
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -2,23 +2,23 @@
 # Clicking either the main map or the bias map picks the profile/time-series
 # location. Both axes are GeoAxis with the same projection, so the click→lonlat
 # transform is identical; only the (figure, axis) pair differs.
-function setup_mouse_click_handler(fig, state::AppState)
-    _register_location_click!(fig, state.ax, state)
-    _register_location_click!(state.fig_bias, state.ax_bias, state)
+function setup_mouse_click_handler(fig, state::AppState, ts_mode_menu)
+    _register_location_click!(fig, state.ax, state, ts_mode_menu)
+    _register_location_click!(state.fig_bias, state.ax_bias, state, ts_mode_menu)
 end
 
-function _register_location_click!(fig, ax, state::AppState)
+function _register_location_click!(fig, ax, state::AppState, ts_mode_menu)
     on(events(fig).mousebutton) do event
         if event.button == Mouse.left && event.action == Mouse.press
             mp = mouseposition(ax)
             trans = Proj.Transformation(ax.dest[], ax.source[]; always_xy = true)
             lonlat = trans(mp)
-            _select_location!(state, lonlat[1], lonlat[2])
+            _select_location!(state, lonlat[1], lonlat[2], ts_mode_menu)
         end
     end
 end
 
-function _select_location!(state::AppState, lon, lat)
+function _select_location!(state::AppState, lon, lat, ts_mode_menu)
     state.lon_profile[] = lon
     state.lat_profile[] = lat
 
@@ -31,16 +31,107 @@ function _select_location!(state::AppState, lon, lat)
     end
 
     state.profile_title[] = profile_title_string(state.var[], state.dates_array, state.time_selected[], state.lon_profile[], state.lat_profile[], state.aggregation_level[])
-    state.timeseries_title[] = timeseries_title_string(state.var[], state.heights, state.height_selected[], state.lon_profile[], state.lat_profile[])
 
-    state.timeseries[] = get_timeseries(state.sim_agg[], state.lon_profile[], state.lat_profile[]; height_selected = state.height_selected[])
-    state.timeseries_obs[] = get_obs_timeseries(state.obs_agg[], state.lon_profile[], state.lat_profile[], length(state.timeseries[]))
+    if state.timeseries_mode[] === :global
+        # A map click means "show me this location" — switch the dropdown back
+        # to Local; its handler recomputes the series at the new location.
+        ts_mode_menu.option_index[] = 1
+    else
+        _update_timeseries!(state)
+    end
+end
+
+# ─── Time series: local (clicked point) vs global mean ─────────────────────
+# The "global" entry's label and mask depend on the component (land mean /
+# full globe / ocean mean) — see MASK_SPECS in utils.jl.
+ts_mode_labels(mask_kind::Symbol) = ["Local (click map)", mask_spec(mask_kind).global_label]
+
+function setup_timeseries_mode_handler(ts_mode_menu, state::AppState)
+    on(ts_mode_menu.value) do label
+        state.updating && return
+        new_mode = startswith(String(label), "Global") ? :global : :local
+        new_mode === state.timeseries_mode[] && return
+        state.timeseries_mode[] = new_mode
+        _update_timeseries!(state)
+    end
+end
+
+# Recompute the time-series pair (sim + obs) and its title for the current
+# mode, location, height, aggregation level and component mask.
+function _update_timeseries!(state::AppState)
+    sim_agg = state.sim_agg[]
+    obs_agg = state.obs_agg[]
+    spec = mask_spec(state.mask_kind)
+    if state.timeseries_mode[] === :global
+        state.timeseries[] = get_global_timeseries(sim_agg; height_selected = state.height_selected[], mask = spec.mask)
+        state.timeseries_obs[] = get_obs_global_timeseries(obs_agg, length(state.timeseries[]); mask = spec.mask)
+    else
+        state.timeseries[] = get_timeseries(sim_agg, state.lon_profile[], state.lat_profile[]; height_selected = state.height_selected[])
+        state.timeseries_obs[] = get_obs_timeseries(obs_agg, state.lon_profile[], state.lat_profile[], length(state.timeseries[]))
+    end
+    state.timeseries_title[] = timeseries_title_string(
+        state.var[], state.heights, state.height_selected[],
+        state.lon_profile[], state.lat_profile[], state.timeseries_mode[],
+        spec.global_label,
+    )
     autolimits!(state.ax_timeseries)
+end
+
+# (Re)build the time-series legend. Makie legends don't track label changes,
+# so this is called whenever the obs product name or line visibility changes
+# (i.e. on variable / aggregation switches).
+function _refresh_timeseries_legend!(state::AppState)
+    isnothing(state.timeseries_legend) || delete!(state.timeseries_legend)
+    plots = Any[state.timeseries_lines]
+    labels = Any["model"]
+    if state.show_obs_line[]
+        push!(plots, state.timeseries_obs_lines)
+        push!(labels, state.obs_name[])
+    end
+    legend = axislegend(
+        state.ax_timeseries, plots, labels;
+        position = :rt, framevisible = false, labelsize = 12, padding = (4, 4, 2, 2),
+    )
+    legend.labelcolor = state.dark_mode[] ? :white : :black
+    state.timeseries_legend = legend
+    return legend
+end
+
+# ─── Coupler component: swap the active SimDir ─────────────────────────────
+# `components` maps a label ("atmos", "land", …) to its `(simdir, bench_cache)`.
+# Switching swaps the data source and benchmark cache, repopulates the variable
+# menu, and selects its first variable — the variable handler then drives the
+# full refresh exactly as if the user had picked a variable.
+function setup_component_handler(component_menu, var_menu, ts_mode_menu, state::AppState, components)
+    on(component_menu.value) do label
+        haskey(components, label) || return
+        entry = components[label]
+        entry.simdir === state.simdir && return
+        state.simdir = entry.simdir
+        state.bench_cache = entry.bench_cache
+        state.mask_kind = component_mask_kind(label)
+        # Reset the time-series mode to Local and relabel its "Global" entry
+        # for the component's mask (land mean / full globe / ocean mean).
+        # Setting the mode first makes the value assignment a no-op in the
+        # dropdown handler; the variable switch below recomputes everything.
+        state.timeseries_mode[] = :local
+        labels = ts_mode_labels(state.mask_kind)
+        ts_mode_menu.option_index[] = 1
+        ts_mode_menu.value[] = first(labels)
+        ts_mode_menu.options[] = labels
+        vars = _sorted_vars(entry.simdir)
+        var_menu.options[] = vars
+        var_menu.value[] = first(vars)
+    end
 end
 
 # ─── Variable / reduction / period: switch active OutputVar ────────────────
 function setup_variable_handler(var_menu, reduction_menu, period_menu, height_slider, time_slider, aggregation_menu, state::AppState)
     on(var_menu.value) do v
+        # The ChoicesBox notifies `nothing` from the JS side whenever its
+        # options are replaced (component switch); the haskey check also drops
+        # any stale selection that doesn't exist in the new component.
+        (isnothing(v) || !haskey(state.simdir.vars, v)) && return
         state.updating = true
         try
             available_reductions = collect(keys(state.simdir.vars[v]))
@@ -55,7 +146,7 @@ function setup_variable_handler(var_menu, reduction_menu, period_menu, height_sl
 
             state.current_reduction = first(available_reductions)
             state.current_period = first(available_periods)
-            new_var = get(state.simdir; short_name = v, reduction = state.current_reduction, period = state.current_period)
+            new_var = load_sim_var(state.simdir, v, state.current_reduction, state.current_period; fallback_start_date = state.fallback_start_date)
             heights_new = has_height(new_var) ? new_var.dims[get_height_dim_name(new_var)] : Float64[]
 
             height_slider.index[] = 1
@@ -85,7 +176,7 @@ function setup_reduction_handler(reduction_menu, period_menu, time_slider, aggre
 
             state.current_reduction = reduction
             state.current_period = first(available_periods)
-            new_var = get(state.simdir; short_name = var_name, reduction = reduction, period = first(available_periods))
+            new_var = load_sim_var(state.simdir, var_name, reduction, first(available_periods); fallback_start_date = state.fallback_start_date)
             heights_new = has_height(new_var) ? new_var.dims[get_height_dim_name(new_var)] : Float64[]
             _update_aggregation_options!(aggregation_menu, new_var, state)
             update_for_new_variable(state, new_var, heights_new, time_slider)
@@ -104,7 +195,7 @@ function setup_period_handler(period_menu, reduction_menu, time_slider, aggregat
             reduction = reduction_menu.value[]
             state.current_reduction = reduction
             state.current_period = period
-            new_var = get(state.simdir; short_name = var_name, reduction = reduction, period = period)
+            new_var = load_sim_var(state.simdir, var_name, reduction, period; fallback_start_date = state.fallback_start_date)
             heights_new = has_height(new_var) ? new_var.dims[get_height_dim_name(new_var)] : Float64[]
             _update_aggregation_options!(aggregation_menu, new_var, state)
             update_for_new_variable(state, new_var, heights_new, time_slider)
@@ -142,11 +233,9 @@ function update_for_new_variable(state::AppState, new_var, heights_new, time_sli
     state.is_loading[] = true
     state.loading_status[] = string("Loading ", ClimaAnalysis.short_name(new_var), "…")
 
-    # New variable invalidates any cached resampled obs / bias limits / metrics.
-    empty!(state.bias_limits_cache)
-    empty!(state.obs_resampled_cache)
-    empty!(state.metrics_cache)
-
+    # The session caches are keyed by (short_name, reduction, period, level),
+    # so entries for other variables stay valid — keep them, switching back is
+    # then instant.
     state.var[] = new_var
     needs_height_update = has_height(new_var)
 
@@ -173,9 +262,10 @@ function update_for_new_variable(state::AppState, new_var, heights_new, time_sli
     state.obs_agg[] = obs_agg
     state.show_bias[] = !isnothing(obs_agg) && _has_lonlat_only(sim_agg)
     state.show_obs_line[] = !isnothing(obs_agg)
+    state.obs_name[] = obs_source_name(isnothing(obs_agg) ? obs : obs_agg)
 
     state.var_sliced[] = var_slice(sim_agg, state.time_selected[]; height_selected = state.height_selected[])
-    state.limits[] = get_limits(sim_agg, state.time_selected[]; height_selected = state.height_selected[])
+    state.limits[] = _cached_limits(state, sim_agg, state.height_selected[])
 
     if has_height(state.var[])
         update_title_with_height(state, state.time_selected[], state.heights[state.height_selected[]])
@@ -190,7 +280,6 @@ function update_for_new_variable(state::AppState, new_var, heights_new, time_sli
     tick_labels = [format_date_short(state.dates_array[i], state.aggregation_level[]) for i in tick_indices]
     state.ax_timeseries.xticks = (tick_indices, tick_labels)
 
-    state.timeseries_title[] = timeseries_title_string(state.var[], state.heights, state.height_selected[], state.lon_profile[], state.lat_profile[])
     state.profile_title[] = profile_title_string(state.var[], state.dates_array, state.time_selected[], state.lon_profile[], state.lat_profile[], state.aggregation_level[])
     state.time_value_text[] = format_date_for_level(state.dates_array[state.time_selected[]], state.aggregation_level[])
 
@@ -206,9 +295,8 @@ function update_for_new_variable(state::AppState, new_var, heights_new, time_sli
         ylims!(state.ax_profile, minimum(state.heights), maximum(state.heights))
     end
 
-    state.timeseries[] = get_timeseries(sim_agg, state.lon_profile[], state.lat_profile[]; height_selected = state.height_selected[])
-    state.timeseries_obs[] = get_obs_timeseries(obs_agg, state.lon_profile[], state.lat_profile[], length(state.timeseries[]))
-    autolimits!(state.ax_timeseries)
+    _update_timeseries!(state)
+    _refresh_timeseries_legend!(state)
 
     state.show_height[] = needs_height_update
 
@@ -216,6 +304,23 @@ function update_for_new_variable(state::AppState, new_var, heights_new, time_sli
 end
 
 _has_lonlat_only(var) = haskey(var.dims, "lon") && haskey(var.dims, "lat") && !has_height(var)
+
+# Fully qualified session-cache key for the active variable at `level`.
+_bench_key(state::AppState, level) = (
+    ClimaAnalysis.short_name(state.var[]),
+    state.current_reduction, state.current_period, level,
+)
+
+# Map colorbar limits for the active variable — a full-field quantile scan,
+# cached per (variable, reduction, period, level, height) so revisiting any
+# combination repaints instantly.
+function _cached_limits(state::AppState, sim_agg, height_selected)
+    key = (_bench_key(state, state.aggregation_level[])..., height_selected)
+    return get!(
+        () -> get_limits(sim_agg, state.time_selected[]; height_selected = height_selected),
+        state.limits_cache, key,
+    )
+end
 
 # ─── Benchmark: bias map + metrics ─────────────────────────────────────────
 # Try to satisfy the benchmark panel for the current (var, reduction, period,
@@ -227,13 +332,14 @@ function _try_cached_benchmark!(state::AppState, var_name, level)
     cache = state.bench_cache
     isnothing(cache) && return nothing
     key = (var_name, state.current_reduction, state.current_period, level)
-    fingerprint = _source_fingerprint(state.simdir, var_name, state.current_reduction, state.current_period)
+    fingerprint = _source_fingerprint(state.simdir, var_name, state.current_reduction, state.current_period) *
+        mask_spec(state.mask_kind).cache_tag
     entry = get_cached_entry(cache, key, fingerprint)
     isnothing(entry) && return nothing
     # Defensive: the cache is grid-specific; bail if the live grid differs.
     (length(entry.lon) == length(state.lon) && length(entry.lat) == length(state.lat)) || return nothing
 
-    base = (var_name, level)
+    base = _bench_key(state, level)
     state.bias_limits_cache[base] = entry.bias_limits
     slot = Dict{Int, Array{Float64, 2}}()
     for t in 1:entry.n
@@ -241,7 +347,7 @@ function _try_cached_benchmark!(state::AppState, var_name, level)
     end
     state.obs_resampled_cache[base] = slot
     for t in 1:entry.n
-        state.metrics_cache[(var_name, level, t)] = MetricsTable(copy(entry.metrics_per_t[t]), entry.units)
+        state.metrics_cache[(base..., t)] = MetricsTable(copy(entry.metrics_per_t[t]), entry.units)
     end
     return entry
 end
@@ -276,9 +382,9 @@ function recompute_benchmark!(state::AppState)
         entry = _try_cached_benchmark!(state, var_name, level)
         if !isnothing(entry)
             _update_bias_slice!(state, sim_trunc, obs_trunc, t)
-            state.bias_title[] = bias_title_string(state.var[], state.dates_array, state.time_selected[], level)
+            state.bias_title[] = bias_title_string(state.var[], state.dates_array, state.time_selected[], level, state.obs_name[])
             state.bias_limits[] = entry.bias_limits
-            mk = (var_name, level, t)
+            mk = (_bench_key(state, level)..., t)
             haskey(state.metrics_cache, mk) && (state.metrics[] = state.metrics_cache[mk])
             state.is_loading[] = false
             state.loading_status[] = ""
@@ -288,9 +394,9 @@ function recompute_benchmark!(state::AppState)
         # Synchronous: cheap bias slice + title, then cached limits if available.
         state.loading_status[] = "Computing bias map…"
         _update_bias_slice!(state, sim_trunc, obs_trunc, t)
-        state.bias_title[] = bias_title_string(state.var[], state.dates_array, state.time_selected[], level)
+        state.bias_title[] = bias_title_string(state.var[], state.dates_array, state.time_selected[], level, state.obs_name[])
 
-        cache_key = (var_name, level)
+        cache_key = _bench_key(state, level)
         if haskey(state.bias_limits_cache, cache_key)
             state.bias_limits[] = state.bias_limits_cache[cache_key]
             limits_ready = true
@@ -331,6 +437,7 @@ function _async_benchmark!(state::AppState, sim_trunc, obs_trunc, t, cache_key, 
         metrics = compute_metrics(
             sim_trunc, obs_trunc;
             selected_idx = t,
+            mask = mask_spec(state.mask_kind).mask,
             scopes = (:selected,),
             compute_seasonal_diagnostics = false,
         )
@@ -353,9 +460,7 @@ end
 # (variable, aggregation level, time index). Falls back to direct resample on
 # any cache miss / failure.
 function _get_obs_resampled_slice(state::AppState, sim_var, obs_var, t, sim_t)
-    var_name = ClimaAnalysis.short_name(state.var[])
-    level = state.aggregation_level[]
-    base_key = (var_name, level)
+    base_key = _bench_key(state, state.aggregation_level[])
     slot = get!(state.obs_resampled_cache, base_key) do
         Dict{Int, Array{Float64, 2}}()
     end
@@ -405,17 +510,17 @@ function setup_aggregation_handler(aggregation_menu, time_slider, state::AppStat
             state.obs_agg[] = obs_agg
             state.show_bias[] = !isnothing(obs_agg) && _has_lonlat_only(sim_agg)
             state.show_obs_line[] = !isnothing(obs_agg)
+            state.obs_name[] = obs_source_name(isnothing(obs_agg) ? obs : obs_agg)
 
             state.var_sliced[] = var_slice(sim_agg, new_idx; height_selected = state.height_selected[])
-            state.limits[] = get_limits(sim_agg, new_idx; height_selected = state.height_selected[])
+            state.limits[] = _cached_limits(state, sim_agg, state.height_selected[])
 
             tick_indices = round.(Int, range(1, length(state.dates_array), length = min(state.n_ticks, length(state.dates_array))))
             tick_labels = [format_date_short(state.dates_array[i], new_level) for i in tick_indices]
             state.ax_timeseries.xticks = (tick_indices, tick_labels)
-            state.timeseries[] = get_timeseries(sim_agg, state.lon_profile[], state.lat_profile[]; height_selected = state.height_selected[])
-            state.timeseries_obs[] = get_obs_timeseries(obs_agg, state.lon_profile[], state.lat_profile[], length(state.timeseries[]))
+            _update_timeseries!(state)
+            _refresh_timeseries_legend!(state)
             state.time_value_text[] = format_date_for_level(state.dates_array[new_idx], new_level)
-            autolimits!(state.ax_timeseries)
 
             # Re-render titles with the new level's date format.
             if has_height(state.var[])
@@ -445,6 +550,10 @@ end
 
 # ─── Time slider ───────────────────────────────────────────────────────────
 function setup_time_handler(time_slider, state::AppState)
+    # Monotone token for the async metrics computation below: each slider tick
+    # bumps it, and a finished computation only lands if its token is still the
+    # newest (results for skipped-over frames are discarded).
+    metrics_request = Ref(0)
     on(time_slider.value) do t
         # Skip while another handler is mid-update (it resizes the slider and
         # repaints everything itself with consistent state).
@@ -480,7 +589,7 @@ function setup_time_handler(time_slider, state::AppState)
                     sim_t = ClimaAnalysis.slice(sim_agg; time = sim_agg.dims["time"][t])
                     obs_resampled_slice = _get_obs_resampled_slice(state, sim_agg, obs_agg, t, sim_t)
                     state.bias_sliced[] = sim_t.data .- obs_resampled_slice
-                    state.bias_title[] = bias_title_string(state.var[], state.dates_array, t, level)
+                    state.bias_title[] = bias_title_string(state.var[], state.dates_array, t, level, state.obs_name[])
                 end
             catch
                 # leave bias_sliced unchanged
@@ -489,21 +598,40 @@ function setup_time_handler(time_slider, state::AppState)
 
         # Metrics update for "Selected" scope only — skip while animating.
         if state.show_bias[] && !state.is_playing[]
-            mk = (ClimaAnalysis.short_name(state.var[]), level, t)
+            mk = (_bench_key(state, level)..., t)
             if haskey(state.metrics_cache, mk)
-                # Cache hit (prefilled from disk): instant.
+                # Cache hit (prefilled from disk or computed earlier): instant.
                 state.metrics[] = state.metrics_cache[mk]
             else
-                try
-                    sim_agg_l = state.sim_agg[]
-                    obs_agg_l = state.obs_agg[]
+                # Cache miss: the :selected metrics cost ~2 s (regridding), so
+                # compute off the handler and apply only if this is still the
+                # newest request — scrubbing stays smooth instead of blocking
+                # per tick (latest-wins via `metrics_request`).
+                request = (metrics_request[] += 1)
+                sim_agg_l = state.sim_agg[]
+                obs_agg_l = state.obs_agg[]
+                prev_metrics = state.metrics[]
+                @async try
                     n = min(length(ClimaAnalysis.dates(sim_agg_l)), length(ClimaAnalysis.dates(obs_agg_l)))
-                    sim_trunc = _select_time_indices(sim_agg_l, collect(1:n))
-                    obs_trunc = _select_time_indices(obs_agg_l, collect(1:n))
-                    new_table = MetricsTable(state.metrics[].units)
-                    merge!(new_table.values, state.metrics[].values)
-                    update_metrics_scope!(new_table, sim_trunc, obs_trunc, :selected; selected_idx = min(t, n))
-                    state.metrics[] = new_table
+                    new_table = MetricsTable(prev_metrics.units)
+                    merge!(new_table.values, prev_metrics.values)
+                    update_metrics_scope!(
+                        new_table,
+                        _select_time_indices(sim_agg_l, collect(1:n)),
+                        _select_time_indices(obs_agg_l, collect(1:n)),
+                        :selected;
+                        mask = mask_spec(state.mask_kind).mask, selected_idx = min(t, n),
+                    )
+                    # Cache regardless; display only if no newer computation
+                    # was requested AND the panel still shows this exact
+                    # (variable, level, frame) — a cache hit or a variable
+                    # switch in between doesn't bump the token, hence the
+                    # full key check.
+                    state.metrics_cache[mk] = new_table
+                    current_key = (_bench_key(state, state.aggregation_level[])..., state.time_selected[])
+                    if metrics_request[] == request && current_key == mk
+                        state.metrics[] = new_table
+                    end
                 catch
                 end
             end
@@ -519,16 +647,14 @@ function setup_height_handler(height_slider, state::AppState)
         end
         sim_agg = state.sim_agg[]
         state.var_sliced[] = var_slice(sim_agg, state.time_selected[]; height_selected = h)
-        state.limits[] = get_limits(sim_agg, state.time_selected[]; height_selected = h)
+        state.limits[] = _cached_limits(state, sim_agg, h)
 
         update_title_with_height(state, state.time_selected[], state.heights[h])
 
-        state.timeseries[] = get_timeseries(sim_agg, state.lon_profile[], state.lat_profile[]; height_selected = h)
-        autolimits!(state.ax_timeseries)
+        _update_timeseries!(state)
 
         state.height_value_text[] = string(round(state.heights[h], digits = 1), " m")
         state.current_height[] = state.heights[h]
-        state.timeseries_title[] = timeseries_title_string(state.var[], state.heights, h, state.lon_profile[], state.lat_profile[])
     end
 end
 
@@ -650,6 +776,6 @@ function setup_dark_mode_handler(state::AppState, session)
         state.ax_timeseries.xgridcolor = (text_color, 0.2)
         state.ax_timeseries.ygridcolor = (text_color, 0.2)
         state.timeseries_lines.color = line_color
-        state.timeseries_legend.labelcolor = text_color
+        isnothing(state.timeseries_legend) || (state.timeseries_legend.labelcolor = text_color)
     end
 end

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -55,7 +55,8 @@ function create_main_figure(var, var_sliced, limits, lon, lat, lon_profile, lat_
 end
 
 # Bias map (sim - obs) with diverging colormap, symmetric around 0.
-function create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat, lon_profile, lat_profile, bg_color)
+# `obs_name` is an Observable with the obs product display name ("ERA5", …).
+function create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat, lon_profile, lat_profile, bg_color, obs_name)
     fig = Figure(size = (1075, 540), backgroundcolor = bg_color, figure_padding = 0)
 
     ax = GeoAxis(fig[1, 1], title = bias_title, titlesize = 16.0f0, dest = "+proj=eqc")
@@ -79,9 +80,9 @@ function create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat,
         color = (:red, 0.7), markersize = 20, marker = :circle,
     )
 
-    colorbar_label = Observable(string(
-        "sim − obs [", ClimaAnalysis.units(var[]), "]",
-    ))
+    colorbar_label = map(var, obs_name) do v, n
+        string("sim − ", n, " [", ClimaAnalysis.units(v), "]")
+    end
 
     cbar = Colorbar(
         fig[2, 1], surface_plot_bias;
@@ -91,10 +92,6 @@ function create_bias_figure(var, bias_sliced, bias_limits, bias_title, lon, lat,
         tellheight = true, tellwidth = false,
     )
     rowgap!(fig.layout, 4)
-
-    on(var) do v
-        colorbar_label[] = string("sim − obs [", ClimaAnalysis.units(v), "]")
-    end
 
     return fig, ax, coastlines_plot, cbar, surface_plot_bias, colorbar_label
 end
@@ -159,20 +156,18 @@ function create_timeseries_figure(
     time_indices = map(t -> collect(1:length(t)), timeseries)
     timeseries_lines = lines!(
         ax_timeseries, time_indices, timeseries;
-        color = :black, linewidth = 2, label = "model",
+        color = :black, linewidth = 2,
     )
     timeseries_obs_lines = lines!(
         ax_timeseries, time_indices, timeseries_obs;
-        color = :orange, linewidth = 2, label = "obs", visible = show_obs_line,
+        color = :orange, linewidth = 2, visible = show_obs_line,
     )
 
     current_time_index = Observable(time_selected[])
     vlines!(ax_timeseries, current_time_index; color = (:grey, 0.7), linewidth = 2)
 
-    timeseries_legend = axislegend(
-        ax_timeseries;
-        position = :rt, framevisible = false, labelsize = 12, padding = (4, 4, 2, 2),
-    )
+    # The legend is created (and recreated when the obs product changes) by
+    # `_refresh_timeseries_legend!` — Makie legends don't track label changes.
 
     n_ticks = min(10, length(dates_array))
     tick_indices = round.(Int, range(1, length(dates_array), length = n_ticks))
@@ -182,5 +177,5 @@ function create_timeseries_figure(
     autolimits!(ax_timeseries)
 
     return fig_timeseries, ax_timeseries, timeseries_ylabel, current_time_index, n_ticks,
-        timeseries_lines, timeseries_obs_lines, timeseries_legend
+        timeseries_lines, timeseries_obs_lines
 end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -1,13 +1,17 @@
 export layout
 
 function layout(
-    var_menu, reduction_menu, period_menu, aggregation_menu,
+    var_menu, reduction_menu, period_menu, aggregation_menu, ts_mode_menu,
     time_slider, height_slider, play_button, speed_slider,
     fig, fig_bias, fig_profile, fig_timeseries,
     show_height, show_bias, metrics, coverage_text,
     time_value_label, height_value_label, speed_value_label,
     dark_mode_checkbox,
-    is_loading, loading_status,
+    is_loading, loading_status, obs_name;
+    run_title = "",
+    component_menu = nothing,
+    summary_button = nothing,
+    summary_overlay = nothing,
 )
     label_style = Bonito.Styles(
         "font-size" => "0.9rem", "font-weight" => "600",
@@ -42,15 +46,32 @@ function layout(
         "background-color" => "#1a1a1a",
     )
 
-    menu_column = Bonito.Col(
-        dark_mode_row,
+    # Optional run caption shown just below the play button.
+    run_title_style = Bonito.Styles(
+        "font-size" => "1.0rem", "font-weight" => "700",
+        "margin" => "8px 0 0 0", "text-align" => "center", "color" => "#9ec5fe",
+    )
+
+    menu_items = Any[dark_mode_row]
+    if !isnothing(component_menu)
+        push!(menu_items, Bonito.Row(Bonito.DOM.h1("Component: "; style = label_style), component_menu))
+    end
+    append!(menu_items, Any[
         Bonito.Row(Bonito.DOM.h1("Variable: "; style = label_style), var_menu),
         Bonito.Row(Bonito.DOM.h1("Aggregation: "; style = label_style), aggregation_menu),
+        Bonito.Row(Bonito.DOM.h1("Time series: "; style = label_style), ts_mode_menu),
         Bonito.Row(Bonito.DOM.h1("Time: "; style = label_style), time_slider, time_value_label),
         height_row,
-        animation_row;
-        height = "auto",
-    )
+        animation_row,
+    ])
+    if !isnothing(summary_button)
+        push!(menu_items, Bonito.Row(summary_button))
+    end
+    if !isempty(run_title)
+        push!(menu_items, Bonito.DOM.div(run_title; style = run_title_style))
+    end
+
+    menu_column = Bonito.Col(menu_items...; height = "auto")
 
     menu_card = Bonito.Card(
         menu_column;
@@ -60,7 +81,7 @@ function layout(
     )
 
     metrics_card = Bonito.Card(
-        _metrics_panel(metrics, coverage_text);
+        _metrics_panel(metrics, coverage_text, obs_name);
         shadow_size = "0",
         style = menu_card_style,
         class = "menu-card metrics-card",
@@ -87,13 +108,15 @@ function layout(
     )
 
     progress_bar, status_label, css_block = _progress_indicator(is_loading, loading_status)
-    return Bonito.Col(css_block, progress_bar, status_label, grid)
+    tail = isnothing(summary_overlay) ? () : (summary_overlay,)
+    return Bonito.Col(css_block, progress_bar, status_label, grid, tail...)
 end
 
 # Compact metrics panel. Always reports the currently selected time frame
 # (`:selected` scope); `coverage_text` shows which period that frame covers
-# (e.g. "January 2009", "MAM 2009", "2009").
-function _metrics_panel(metrics, coverage_text)
+# (e.g. "January 2009", "MAM 2009", "2009"). `obs_name` is the obs product
+# display name, used to label the obs rows ("ERA5 mean" instead of "Obs mean").
+function _metrics_panel(metrics, coverage_text, obs_name)
     label_style = Bonito.Styles(
         "font-size" => "1.1rem", "font-weight" => "600",
         "padding" => "4px 8px", "color" => "white", "text-align" => "left",
@@ -121,8 +144,9 @@ function _metrics_panel(metrics, coverage_text)
     rows = Any[]
     for m in METRIC_ROWS
         value_text = map(t -> format_cell(t, m, :selected), metrics)
+        row_label = m === :obs_mean ? map(n -> string(n, " mean"), obs_name) : METRIC_LABELS[m]
         push!(rows, Bonito.DOM.div(
-            Bonito.DOM.span(METRIC_LABELS[m]; style = label_style),
+            Bonito.DOM.span(row_label; style = label_style),
             Bonito.DOM.span(value_text; style = value_style);
             style = row_style,
         ))

--- a/src/summary.jl
+++ b/src/summary.jl
@@ -1,0 +1,317 @@
+# ─── Model performance summary ───────────────────────────────────────────────
+#
+# One-glance benchmark overview: a modal overlay (opened by the "Model summary"
+# menu button) showing, for every variable of the active SimDir that has a
+# registered observation, the global ocean-masked RMSE (and bias) against the
+# benchmark over the whole simulation period, per season (All-time / DJF / MAM /
+# JJA / SON). Cells are colored by RMSE relative to the observed all-time mean,
+# green → red, so model performance reads as one image.
+#
+# The table is plain DOM (no WebGL), so it renders fine inside an initially
+# hidden overlay. Results are cached per component for the session and, when
+# the benchmark cache is enabled, persisted to `.climaviz_cache/summary.jls`
+# (fingerprinted like the per-variable benchmark entries).
+
+const _SUMMARY_SCOPES = (:all_time, :DJF, :MAM, :JJA, :SON)
+const _SUMMARY_SCOPE_TITLES = ("All-time", "DJF", "MAM", "JJA", "SON")
+const _SUMMARY_CACHE_FILE = "summary.jls"
+
+# ─── Data ─────────────────────────────────────────────────────────────────────
+
+# Candidate (short_name, reduction, period) triples: variables of `simdir` with
+# a registered obs loader, taking the first reduction/period like the menus do.
+function _summary_candidates(simdir, obs_bundle)
+    candidates = Tuple{String, String, Any}[]
+    for short_name in _sorted_vars(simdir)
+        has_obs(obs_bundle, short_name) || continue
+        reduction = first(keys(simdir.vars[short_name]))
+        period = first(keys(simdir.vars[short_name][reduction]))
+        push!(candidates, (short_name, reduction, period))
+    end
+    return candidates
+end
+
+_summary_fingerprint(simdir, candidates) = join(
+    (string(sn, "/", red, "/", per, "=", _source_fingerprint(simdir, sn, red, per))
+     for (sn, red, per) in candidates),
+    "||",
+)
+
+"""
+    compute_summary_rows(simdir, obs_bundle; fallback_start_date, mask, on_progress)
+
+Compute the model-summary benchmark rows for `simdir`: one NamedTuple per
+variable with a registered observation, holding the per-scope global RMSE and
+bias (`Dict{Symbol, Float64}` keyed by `_SUMMARY_SCOPES`) over the full
+overlapping sim/obs period, plus units, the obs product name and the observed
+all-time mean (used to normalize the cell colors). `mask` is the component's
+spatial mask (see `MASK_SPECS`). `on_progress` is called with each short_name
+before its (slow) metrics computation.
+"""
+function compute_summary_rows(
+    simdir, obs_bundle;
+    fallback_start_date = nothing, mask = ClimaAnalysis.apply_oceanmask, on_progress = nothing,
+)
+    rows = NamedTuple[]
+    for (short_name, reduction, period) in _summary_candidates(simdir, obs_bundle)
+        var = try
+            load_sim_var(simdir, short_name, reduction, period; fallback_start_date)
+        catch e
+            @warn "ClimaViz summary: failed to load $short_name" exception = e
+            continue
+        end
+        _has_lonlat_only(var) || continue
+        obs = get_obs(obs_bundle, short_name)
+        isnothing(obs) && continue
+        obs_agg = aggregate_obs(obs, var, :native)
+        isnothing(obs_agg) && continue
+        isnothing(on_progress) || on_progress(short_name)
+        n = min(length(ClimaAnalysis.dates(var)), length(ClimaAnalysis.dates(obs_agg)))
+        sim_trunc = _select_time_indices(var, collect(1:n))
+        obs_trunc = _select_time_indices(obs_agg, collect(1:n))
+        t = compute_metrics(
+            sim_trunc, obs_trunc;
+            mask = mask, scopes = _SUMMARY_SCOPES, compute_seasonal_diagnostics = false,
+        )
+        push!(rows, (
+            short_name = short_name,
+            units = ClimaAnalysis.units(var),
+            obs_name = obs_source_name(obs_agg),
+            rmse = Dict(s => t[:rmse, s] for s in _SUMMARY_SCOPES),
+            bias = Dict(s => t[:bias, s] for s in _SUMMARY_SCOPES),
+            obs_mean = t[:obs_mean, :all_time],
+        ))
+    end
+    return rows
+end
+
+# ─── Persistence (piggybacks on the benchmark cache directory) ────────────────
+
+function _cached_summary_rows(bench_cache, fingerprint)
+    (isnothing(bench_cache) || isnothing(bench_cache.dir)) && return nothing
+    file = joinpath(bench_cache.dir, _SUMMARY_CACHE_FILE)
+    isfile(file) || return nothing
+    payload = try
+        deserialize(file)
+    catch e
+        @debug "ClimaViz: unreadable summary cache; will recompute" file exception = e
+        return nothing
+    end
+    payload isa NamedTuple || return nothing
+    Base.get(payload, :version, 0) == _CACHE_FORMAT_VERSION || return nothing
+    Base.get(payload, :fingerprint, "") == fingerprint || return nothing
+    return payload.rows
+end
+
+function _store_summary_rows!(bench_cache, fingerprint, rows)
+    (isnothing(bench_cache) || isnothing(bench_cache.dir)) && return rows
+    file = joinpath(bench_cache.dir, _SUMMARY_CACHE_FILE)
+    try
+        tmp = file * ".tmp"
+        serialize(tmp, (version = _CACHE_FORMAT_VERSION, fingerprint = fingerprint, rows = rows))
+        mv(tmp, file; force = true)
+    catch e
+        @warn "ClimaViz: failed to write summary cache" file exception = e
+    end
+    return rows
+end
+
+"""
+    precompute_summary!(simdir, bench_cache, obs; fallback_start_date = nothing, mask_kind = :land)
+
+Warm the persistent model-summary cache for `simdir` (skipped if already up to
+date), so the first "Model summary" click is instant. Called by
+[`dashboard`](@ref) when `precompute = true`.
+"""
+function precompute_summary!(simdir, bench_cache, obs; fallback_start_date = nothing, mask_kind::Symbol = :land)
+    spec = mask_spec(mask_kind)
+    bundle = ObsBundle(obs; start_date = fallback_start_date)
+    fingerprint = _summary_fingerprint(simdir, _summary_candidates(simdir, bundle)) * spec.cache_tag
+    isnothing(_cached_summary_rows(bench_cache, fingerprint)) || return nothing
+    rows = compute_summary_rows(simdir, bundle; fallback_start_date, mask = spec.mask)
+    _store_summary_rows!(bench_cache, fingerprint, rows)
+    return nothing
+end
+
+# ─── Rendering ────────────────────────────────────────────────────────────────
+
+# Compact number formatting matching `format_cell`'s magnitude rules.
+function _summary_format(v)
+    isnan(v) && return "—"
+    return (v == 0 || abs(v) >= 0.1) ? string(round(v; digits = 2)) :
+           string(round(v; sigdigits = 3))
+end
+
+_hex2(x) = string(round(Int, clamp(x, 0, 255)); base = 16, pad = 2)
+_lerp_rgb(a, b, t) = string("#", _hex2(a[1] + (b[1] - a[1]) * t),
+    _hex2(a[2] + (b[2] - a[2]) * t), _hex2(a[3] + (b[3] - a[3]) * t))
+
+# Cell color from RMSE relative to |obs mean|: green (≤25 %) through yellow
+# (~75 %) to red (≥125 %); gray when the ratio is undefined. RGB components as
+# Ints — UInt8 differences would wrap around in the lerp.
+function _rmse_cell_color(rmse, obs_mean)
+    (isnan(rmse) || isnan(obs_mean) || obs_mean == 0) && return "#555555"
+    green, yellow, red = (46, 125, 50), (196, 143, 16), (198, 40, 40)
+    rel = rmse / abs(obs_mean)
+    rel <= 0.25 && return _lerp_rgb(green, green, 0.0)
+    rel <= 0.75 && return _lerp_rgb(green, yellow, (rel - 0.25) / 0.5)
+    rel <= 1.25 && return _lerp_rgb(yellow, red, (rel - 0.75) / 0.5)
+    return _lerp_rgb(red, red, 0.0)
+end
+
+function _summary_table_node(rows; mask_note = "land-only (ocean-masked)")
+    isempty(rows) && return Bonito.DOM.div(
+        "No benchmark observations are registered for this component's variables.";
+        style = "padding: 16px; font-size: 1.0rem;",
+    )
+    header_style = "font-weight: 700; font-size: 0.95rem; padding: 6px 10px; text-align: center;"
+    label_style = "font-size: 0.95rem; padding: 8px 10px; text-align: left; white-space: nowrap;"
+    cell_style(color) = string(
+        "background: ", color, "; color: white; border-radius: 4px;",
+        "padding: 6px 10px; text-align: center; min-width: 92px;",
+        "font-variant-numeric: tabular-nums;",
+    )
+    cells = Any[Bonito.DOM.div(""; style = header_style)]
+    for title in _SUMMARY_SCOPE_TITLES
+        push!(cells, Bonito.DOM.div(title; style = header_style))
+    end
+    for r in rows
+        push!(cells, Bonito.DOM.div(
+            Bonito.DOM.div(string(r.short_name, " [", r.units, "]"); style = "font-weight: 700;"),
+            Bonito.DOM.div(string("vs ", r.obs_name); style = "font-size: 0.8rem; opacity: 0.8;");
+            style = label_style,
+        ))
+        for s in _SUMMARY_SCOPES
+            push!(cells, Bonito.DOM.div(
+                Bonito.DOM.div(_summary_format(r.rmse[s]); style = "font-weight: 700;"),
+                Bonito.DOM.div(string("bias ", _summary_format(r.bias[s])); style = "font-size: 0.8rem; opacity: 0.85;");
+                style = cell_style(_rmse_cell_color(r.rmse[s], r.obs_mean)),
+            ))
+        end
+    end
+    caption = Bonito.DOM.div(
+        string(
+            "Global ", mask_note, " RMSE (and bias) vs. observation, full simulation period. ",
+            "Color: RMSE relative to the observed all-time mean (green ≤ 25 %, red ≥ 125 %).",
+        );
+        style = "font-size: 0.85rem; opacity: 0.8; margin-top: 10px; max-width: 640px;",
+    )
+    grid = Bonito.DOM.div(
+        cells...;
+        style = string(
+            "display: grid; grid-template-columns: max-content repeat(",
+            length(_SUMMARY_SCOPES), ", auto); gap: 3px; align-items: stretch;",
+        ),
+    )
+    return Bonito.DOM.div(grid, caption)
+end
+
+# ─── UI: button + modal overlay ───────────────────────────────────────────────
+
+"""
+    summary_ui(component_label)
+
+Build the "Model summary" button and the (initially hidden) modal overlay.
+Returns `(summary_button, overlay, show_summary, summary_content)`; wire the
+button with [`setup_summary_handler`](@ref) once the `AppState` exists.
+`component_label` is an Observable with the active component name (`""` for
+single-component runs).
+"""
+function summary_ui(component_label)
+    show_summary = Observable(false)
+    summary_content = Observable{Any}(Bonito.DOM.div("Computing summary…"))
+
+    button_style = Bonito.Styles(
+        "padding" => "8px 12px", "font-size" => "0.95rem", "font-weight" => "bold",
+        "border-radius" => "4px", "border" => "2px solid #888888",
+        "background-color" => "#888888", "color" => "white", "cursor" => "pointer",
+    )
+    summary_button = Bonito.Button("Model summary"; style = button_style)
+    close_button = Bonito.Button("Close"; style = button_style)
+    on(close_button) do _
+        show_summary[] = false
+    end
+
+    overlay_style = map(show_summary) do visible
+        string(
+            "position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;",
+            "z-index: 1000; background: rgba(0, 0, 0, 0.65);",
+            "align-items: center; justify-content: center;",
+            "display: ", visible ? "flex" : "none", ";",
+        )
+    end
+
+    subtitle = map(component_label) do label
+        isempty(label) ? "" : string("Component: ", label)
+    end
+    panel = Bonito.DOM.div(
+        Bonito.DOM.div(
+            Bonito.DOM.h2("Model performance summary";
+                style = "margin: 0; font-size: 1.3rem; font-weight: 700;"),
+            close_button;
+            style = "display: flex; justify-content: space-between; align-items: center; gap: 24px; margin-bottom: 4px;",
+        ),
+        Bonito.DOM.div(subtitle; style = "font-size: 1.0rem; color: #9ec5fe; margin-bottom: 12px;"),
+        summary_content;
+        class = "menu-card",
+        style = string(
+            "background: #1a1a1a; color: white; padding: 20px 24px;",
+            "border-radius: 8px; max-height: 90vh; max-width: 90vw; overflow: auto;",
+            "box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);",
+        ),
+    )
+    overlay = Bonito.DOM.div(panel; style = overlay_style)
+    return summary_button, overlay, show_summary, summary_content
+end
+
+"""
+    setup_summary_handler(summary_button, show_summary, summary_content, state, component_label)
+
+Wire the "Model summary" button: on click, open the overlay and (once per
+component and session) compute the summary rows for the active SimDir — served
+from the persistent cache when available, otherwise computed asynchronously
+with progress shown in the dashboard loading bar.
+"""
+function setup_summary_handler(summary_button, show_summary, summary_content, state::AppState, component_label)
+    computed = Dict{String, Any}()
+    computing = Ref(false)
+    on(summary_button) do _
+        show_summary[] = true
+        label = component_label[]
+        spec = mask_spec(state.mask_kind)
+        if haskey(computed, label)
+            summary_content[] = _summary_table_node(computed[label]; mask_note = spec.summary_note)
+            return
+        end
+        computing[] && return
+        computing[] = true
+        summary_content[] = Bonito.DOM.div("Computing summary… (first open per component is slow)")
+        simdir = state.simdir
+        obs_bundle = state.obs_bundle
+        bench_cache = state.bench_cache
+        fallback_start_date = state.fallback_start_date
+        @async try
+            state.is_loading[] = true
+            fingerprint = _summary_fingerprint(simdir, _summary_candidates(simdir, obs_bundle)) * spec.cache_tag
+            rows = _cached_summary_rows(bench_cache, fingerprint)
+            if isnothing(rows)
+                rows = compute_summary_rows(
+                    simdir, obs_bundle;
+                    fallback_start_date,
+                    mask = spec.mask,
+                    on_progress = sn -> (state.loading_status[] = string("Summary: benchmarking ", sn, "…")),
+                )
+                _store_summary_rows!(bench_cache, fingerprint, rows)
+            end
+            computed[label] = rows
+            summary_content[] = _summary_table_node(rows; mask_note = spec.summary_note)
+        catch e
+            @warn "ClimaViz: summary computation failed" exception = (e, catch_backtrace())
+            summary_content[] = Bonito.DOM.div(string("Summary failed: ", sprint(showerror, e)))
+        finally
+            computing[] = false
+            state.is_loading[] = false
+            state.loading_status[] = ""
+        end
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,6 +42,8 @@ mutable struct AppState
     timeseries::Observable
     timeseries_obs::Observable      # parallel obs series (NaN where missing)
     show_obs_line::Observable       # mirrors show_bias for the obs line
+    timeseries_mode::Observable     # Symbol: :local (clicked point) or :global (land mean)
+    obs_name::Observable            # display name of the obs product ("ERA5", …)
     timeseries_title::Observable
     timeseries_ylabel::Observable
     current_time_index::Observable
@@ -89,12 +91,18 @@ mutable struct AppState
     fig_profile::Any
     fig_timeseries::Any
 
-    # Caches keyed by (variable short_name, aggregation level)
-    bias_limits_cache::Dict{Tuple{String, Symbol}, Tuple{Float64, Float64}}
-    obs_resampled_cache::Dict{Tuple{String, Symbol}, Any}
-    # Per-(short_name, level, time index) :selected MetricsTable, prefilled from
-    # the persistent cache so time-slider scrubbing is instant.
-    metrics_cache::Dict{Tuple{String, Symbol, Int}, Any}
+    # Session caches keyed by (short_name, reduction, period, level[, …]).
+    # Keys are fully qualified, so entries stay valid for the whole session and
+    # are kept across variable switches — flipping back to an already-visited
+    # variable is then instant instead of redoing regridding/quantiles/metrics.
+    bias_limits_cache::Dict{Tuple{String, String, String, Symbol}, Tuple{Float64, Float64}}
+    obs_resampled_cache::Dict{Tuple{String, String, String, Symbol}, Any}
+    # Per-(…, time index) :selected MetricsTable, prefilled from the persistent
+    # cache so time-slider scrubbing is instant.
+    metrics_cache::Dict{Tuple{String, String, String, Symbol, Int}, Any}
+    # Map colorbar limits per (…, height index) — a full-field quantile scan
+    # otherwise repeated on every variable/aggregation/height switch.
+    limits_cache::Dict{Tuple{String, String, String, Symbol, Int}, Tuple{Float64, Float64}}
 
     # Persistent benchmark cache controller (BenchmarkCache) or nothing.
     bench_cache::Any
@@ -102,10 +110,55 @@ mutable struct AppState
     # half, short_name + level, is read off `var` / `aggregation_level`).
     current_reduction::String
     current_period::String
+    # start_date (ISO string) substituted into variables whose files lack the
+    # attribute — the atmos start_date in coupled mode, `nothing` otherwise.
+    fallback_start_date::Any
+    # Spatial mask for "global" statistics, keyed into MASK_SPECS — :land
+    # (ocean-masked), :globe (atmos, no mask) or :ocean (land-masked).
+    mask_kind::Symbol
 
     # Misc
     n_ticks::Int
     updating::Bool
+end
+
+# Variable short names of a SimDir in stable (alphabetical) order.
+_sorted_vars(simdir) = sort!(collect(String, keys(simdir.vars)))
+
+# ─── Per-component spatial masking ───────────────────────────────────────────
+# The dashboard's "global" statistics — global time series, the metrics table
+# (Sim/Obs mean, Bias, RMSE) and the model summary — restrict the area-weighted
+# mean to where the component's fields are meaningful: land for ClimaLand
+# output (the ocean-masked convention this dashboard always used), the full
+# globe for atmos, ocean for the ocean/seaice components. `cache_tag` is
+# appended to persistent-cache fingerprints so mask changes invalidate stale
+# entries; it is empty for `:land` to keep pre-existing caches valid.
+const MASK_SPECS = (
+    land = (mask = ClimaAnalysis.apply_oceanmask, global_label = "Global (land mean)",
+            summary_note = "land-only (ocean-masked)", cache_tag = ""),
+    globe = (mask = nothing, global_label = "Global",
+             summary_note = "full-globe", cache_tag = "|mask=globe"),
+    ocean = (mask = ClimaAnalysis.apply_landmask, global_label = "Global (ocean mean)",
+             summary_note = "ocean-only (land-masked)", cache_tag = "|mask=ocean"),
+)
+
+mask_spec(kind::Symbol) = getproperty(MASK_SPECS, kind)
+
+component_mask_kind(label) =
+    label == "atmos" ? :globe :
+    label in ("ocean", "seaice") ? :ocean : :land
+
+# Load a simulation variable in display units. If the source file lacks the
+# `start_date` attribute (seen on ClimaLand output inside coupler runs, and
+# required by `ClimaAnalysis.dates`), substitute `fallback_start_date` (the
+# atmos one in coupled mode). The patch mutates the SimDir-cached OutputVar,
+# so it sticks for later loads of the same variable.
+function load_sim_var(simdir, short_name, reduction, period; fallback_start_date = nothing)
+    var = get(simdir; short_name = short_name, reduction = reduction, period = period)
+    if !haskey(var.attributes, "start_date") && !isnothing(fallback_start_date)
+        var.attributes["start_date"] = string(fallback_start_date)
+    end
+    return to_display_units(var)
 end
 
 # Check if variable has height dimension
@@ -217,16 +270,40 @@ end
 function get_obs_timeseries(obs_var, lon, lat, sim_length)
     isnothing(obs_var) && return fill(NaN, sim_length)
     data = ClimaAnalysis.slice(obs_var; lon = lon, lat = lat).data
-    n = length(data)
-    if n == sim_length
-        return collect(Float64, data)
-    elseif n < sim_length
-        out = fill(NaN, sim_length)
-        out[1:n] .= data
-        return out
-    else
-        return collect(Float64, data[1:sim_length])
+    return _pad_series(data, sim_length)
+end
+
+# Pad with NaN (or truncate) a series to exactly `n` entries.
+function _pad_series(data, n)
+    out = fill(NaN, n)
+    m = min(length(data), n)
+    out[1:m] .= data[1:m]
+    return out
+end
+
+# Area-weighted global mean per time step (NaN-aware) under `mask` — the same
+# convention as the "Sim mean" / "Obs mean" metrics rows. The default mask is
+# the land-only (ocean-masked) one; pass `mask = nothing` for the full globe
+# (atmos). For variables with a height dimension, the mean is taken at the
+# selected height.
+function get_global_timeseries(var; height_selected = 1, mask = ClimaAnalysis.apply_oceanmask)
+    if has_height(var)
+        z_dim = get_height_dim_name(var)
+        var = ClimaAnalysis.slice(var; Symbol(z_dim) => var.dims[z_dim][height_selected])
     end
+    masked = isnothing(mask) ? var :
+        try
+            mask(var)
+        catch
+            var
+        end
+    return collect(Float64, vec(ClimaAnalysis.weighted_average_lonlat(masked).data))
+end
+
+# Global obs series under the same mask, padded/truncated to the sim length.
+function get_obs_global_timeseries(obs_var, sim_length; mask = ClimaAnalysis.apply_oceanmask)
+    isnothing(obs_var) && return fill(NaN, sim_length)
+    return _pad_series(get_global_timeseries(obs_var; mask), sim_length)
 end
 
 const _MONTH_TO_SEASON = Dict(
@@ -297,24 +374,22 @@ function profile_title_string(var, dates_array, time_idx, lon_val, lat_val, leve
     )
 end
 
-function timeseries_title_string(var, heights, height_idx, lon_val, lat_val)
+function timeseries_title_string(var, heights, height_idx, lon_val, lat_val, mode::Symbol = :local, global_label = "Global (land mean)")
+    where_str = mode === :global ? global_label :
+        string("Lon: ", round(lon_val, digits = 2), "°, Lat: ", round(lat_val, digits = 2), "°")
     if has_height(var)
         return string(
             ClimaAnalysis.short_name(var), " - Time Series\n",
-            "Height: ", round(heights[height_idx], digits = 1), " m, ",
-            "Lon: ", round(lon_val, digits = 2), "°, Lat: ", round(lat_val, digits = 2), "°",
+            "Height: ", round(heights[height_idx], digits = 1), " m, ", where_str,
         )
     else
-        return string(
-            ClimaAnalysis.short_name(var), " - Time Series\n",
-            "Lon: ", round(lon_val, digits = 2), "°, Lat: ", round(lat_val, digits = 2), "°",
-        )
+        return string(ClimaAnalysis.short_name(var), " - Time Series\n", where_str)
     end
 end
 
-function bias_title_string(var, dates_array, time_idx, level::Symbol = :native)
+function bias_title_string(var, dates_array, time_idx, level::Symbol = :native, obs_name = "Obs")
     return string(
-        "Sim − Obs: ", ClimaAnalysis.short_name(var), " [",
+        "Sim − ", obs_name, ": ", ClimaAnalysis.short_name(var), " [",
         ClimaAnalysis.units(var), "]\n",
         format_date_for_level(dates_array[time_idx], level),
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using Test
 using ClimaViz
+import ClimaAnalysis
 
 @testset "ClimaViz.jl" begin
     include("test_utils.jl")
     include("test_cache.jl")
+    include("test_coupler.jl")
 end

--- a/test/test_coupler.jl
+++ b/test/test_coupler.jl
@@ -1,0 +1,108 @@
+@testset "Coupler components" begin
+
+    # SimDir only scans filenames, so empty placeholder files are enough to
+    # exercise discovery and pruning.
+    function make_fake_coupler_dir()
+        dir = mktempdir()
+        atmos = joinpath(dir, "clima_atmos")
+        land = joinpath(dir, "clima_land")
+        ocean = joinpath(dir, "clima_ocean")
+        mkpath.((atmos, land, ocean))
+        for f in (
+            "ta_1M_average.nc", "ta_1M_average_pressure.nc",
+            "pr_1M_average.nc", "orog_inst.nc", "day31.0.hdf5", "amip.yml",
+        )
+            touch(joinpath(atmos, f))
+        end
+        touch(joinpath(land, "gpp_1M_average.nc"))
+        # ocean stays empty (inactive component), clima_seaice doesn't exist
+        return dir
+    end
+
+    @testset "discover_components" begin
+        dir = make_fake_coupler_dir()
+        comps = ClimaViz.discover_components(dir)
+        @test [c.label for c in comps] == ["atmos", "land"]
+        @test comps[1].path == joinpath(dir, "clima_atmos")
+
+        atmos = comps[1].simdir
+        # Pruned to monthly native-grid diagnostics: no orog (inst, no period),
+        # no pressure-level coordinate variants.
+        @test sort(collect(keys(atmos.vars))) == ["pr", "ta"]
+        for sn in keys(atmos.vars), red in keys(atmos.vars[sn]), per in keys(atmos.vars[sn][red])
+            @test per == "1M"
+            @test collect(keys(atmos.vars[sn][red][per])) == [nothing]
+        end
+
+        @test sort(collect(keys(comps[2].simdir.vars))) == ["gpp"]
+        @test ClimaViz.discover_components(mktempdir()) == []
+    end
+
+    @testset "_prune_to_1M! prunes variable_paths too" begin
+        dir = make_fake_coupler_dir()
+        comps = ClimaViz.discover_components(dir)
+        paths = comps[1].simdir.variable_paths
+        @test sort(collect(keys(paths))) == ["pr", "ta"]
+        @test collect(keys(paths["ta"]["average"]["1M"])) == [nothing]
+    end
+
+    @testset "_sorted_vars" begin
+        simdir = (vars = Dict("b" => 1, "a" => 2, "c" => 3),)
+        @test ClimaViz._sorted_vars(simdir) == ["a", "b", "c"]
+    end
+
+    @testset "mask specs" begin
+        @test ClimaViz.component_mask_kind("atmos") == :globe
+        @test ClimaViz.component_mask_kind("land") == :land
+        @test ClimaViz.component_mask_kind("ocean") == :ocean
+        @test ClimaViz.component_mask_kind("seaice") == :ocean
+        @test isnothing(ClimaViz.mask_spec(:globe).mask)
+        @test ClimaViz.mask_spec(:land).mask === ClimaAnalysis.apply_oceanmask
+        # An empty :land tag keeps pre-existing (ocean-masked) caches valid;
+        # the others must differ so a mask change invalidates stale entries.
+        @test ClimaViz.mask_spec(:land).cache_tag == ""
+        @test ClimaViz.mask_spec(:globe).cache_tag != ClimaViz.mask_spec(:ocean).cache_tag != ""
+        @test ClimaViz.ts_mode_labels(:globe) == ["Local (click map)", "Global"]
+        @test ClimaViz.ts_mode_labels(:land) == ["Local (click map)", "Global (land mean)"]
+        @test ClimaViz.ts_mode_labels(:ocean)[2] == "Global (ocean mean)"
+    end
+end
+
+@testset "Summary" begin
+    @testset "_summary_format" begin
+        @test ClimaViz._summary_format(NaN) == "—"
+        @test ClimaViz._summary_format(12.344) == "12.34"
+        @test ClimaViz._summary_format(0.0123) == "0.0123"
+        @test ClimaViz._summary_format(0.0) == "0.0"
+    end
+
+    @testset "_rmse_cell_color" begin
+        gray = "#555555"
+        @test ClimaViz._rmse_cell_color(NaN, 1.0) == gray
+        @test ClimaViz._rmse_cell_color(1.0, NaN) == gray
+        @test ClimaViz._rmse_cell_color(1.0, 0.0) == gray
+        @test ClimaViz._rmse_cell_color(0.1, 1.0) == "#2e7d32"   # ≤ 25 % → green
+        @test ClimaViz._rmse_cell_color(10.0, 1.0) == "#c62828"  # ≥ 125 % → red
+        # mid ramp: exact green↔yellow midpoint (guards against the UInt8
+        # wrap-around bug — blue must decrease toward yellow, not wrap to ~220)
+        @test ClimaViz._rmse_cell_color(0.5, 1.0) == "#798621"
+    end
+
+    @testset "_summary_table_node" begin
+        empty_node = ClimaViz._summary_table_node(NamedTuple[])
+        @test occursin("No benchmark", string(empty_node))
+        rows = [(
+            short_name = "lhf", units = "W m^-2", obs_name = "ERA5",
+            rmse = Dict(s => 10.0 for s in ClimaViz._SUMMARY_SCOPES),
+            bias = Dict(s => -2.0 for s in ClimaViz._SUMMARY_SCOPES),
+            obs_mean = 40.0,
+        )]
+        # Note: Hyperscript HTML-escapes brackets ([ → &#91;), so match pieces.
+        node = string(ClimaViz._summary_table_node(rows))
+        @test occursin("lhf", node) && occursin("W m^-2", node)
+        @test occursin("vs ERA5", node)
+        @test occursin("DJF", node)
+        @test occursin("10.0", node)
+        @test occursin("bias -2.0", node)
+    end
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -20,11 +20,12 @@
         @test min_val ≈ 1.0
         @test max_val ≈ 5.0
 
-        # Test with single value (edge case)
+        # Test with single value (edge case): a flat profile gets a
+        # ±(0.1|v| + 0.1) buffer so the axis never has a zero-width range.
         profile_data_single = [3.0]
         min_val, max_val = ClimaViz.get_profile_limits(profile_data_single)
-        @test min_val == 3.0  # No range, no padding
-        @test max_val == 3.0
+        @test min_val ≈ 2.6
+        @test max_val ≈ 3.4
     end
 
     @testset "has_height" begin
@@ -55,5 +56,33 @@
         # but we can ensure it runs without errors
         @test (ClimaViz.print_startup_message(8080); true)
         @test (ClimaViz.print_startup_message(3000); true)
+    end
+
+    @testset "_pad_series" begin
+        @test ClimaViz._pad_series([1.0, 2.0], 4) ≈ [1.0, 2.0, NaN, NaN] nans = true
+        @test ClimaViz._pad_series([1.0, 2.0, 3.0], 2) == [1.0, 2.0]
+        @test ClimaViz._pad_series([1.0, 2.0], 2) == [1.0, 2.0]
+    end
+
+    @testset "obs_source_name" begin
+        @test ClimaViz.obs_source_name(nothing) == "obs"
+        tagged = (attributes = Dict("obs_source" => "ERA5"),)
+        untagged = (attributes = Dict{String, Any}(),)
+        @test ClimaViz.obs_source_name(tagged) == "ERA5"
+        @test ClimaViz.obs_source_name(untagged) == "obs"
+    end
+
+    @testset "timeseries_title_string modes" begin
+        var = ClimaAnalysis.OutputVar(
+            Dict{String, Any}("short_name" => "lhf"),
+            Dict("time" => [0.0, 1.0, 2.0]),
+            Dict{String, Dict}(),
+            [1.0, 2.0, 3.0],
+        )
+        t_local = ClimaViz.timeseries_title_string(var, Float64[], 1, -118.25, 34.05, :local)
+        t_global = ClimaViz.timeseries_title_string(var, Float64[], 1, -118.25, 34.05, :global)
+        @test occursin("Lon: -118.25°, Lat: 34.05°", t_local)
+        @test occursin("Global (land mean)", t_global)
+        @test occursin("lhf", t_global)
     end
 end


### PR DESCRIPTION
Adds observation benchmarking for carbon and atmosphere variables, ClimaCoupler (multi-component) support, a one-page model performance summary, and a responsiveness pass.

## Benchmarks
- **Carbon**: `nee` (CarbonTracker CT2022), `gpp` (GOSIF-GPP v2), `er` (residual NEE+GPP), `hr` (Hashimoto 2015), from the `inversion_nee` artifact. Carbon fluxes are displayed in `g C m⁻² day⁻¹`.
- **ERA5 surface fluxes** registered under both the ClimaLand names (`lhf`, `shf`, `lwu`, `swu`) and the ClimaAtmos/CMIP names (`hfls`, `hfss`, `rlus`, `rsus`).
- Observation **product names** (ERA5, GOSIF, CarbonTracker, …) shown in the time-series legend, bias map title/colorbar, and metrics rows.

## Dashboard features
- **`dashboard(path; coupled = true)`** for ClimaCoupler outputs: a Component menu (atmos / land / ocean / seaice; empty components hidden), atmos restricted to its monthly `_1M_` native-grid diagnostics, missing land `start_date` inherits the atmos one, per-component benchmark caches.
- **"Model summary" button**: overlay with the global RMSE (and bias) of every benchmarked variable over the full simulation period, per season (All-time/DJF/MAM/JJA/SON), color-coded by RMSE relative to the observed mean — model performance in one image. Persisted in the cache; `precompute = true` warms it.
- **Time-series mode menu**: Local (click map) or Global. Global statistics (time series, metrics table, summary) follow the component's spatial mask: ocean-masked land mean for land runs, full globe for atmos, land-masked ocean mean for ocean/seaice.
- `run_title` kwarg for a caption in the menu.

## Responsiveness
- Benchmark session caches are keyed `(variable, reduction, period, level)` and retained across variable switches — revisiting a variable repaints instantly.
- Colorbar limits (full-field quantile scan) cached per (variable, …, height).
- Time-slider scrubbing no longer blocks ~2 s per tick on a cache miss: per-frame metrics run asynchronously with latest-wins semantics.

## Docs & tests
- New **Dashboard** docs page (usage, menus, benchmarks, coupled mode, custom obs loaders, caching); obs registries added to the API reference.
- `test/test_coupler.jl`: component discovery, `_1M_` pruning, mask specs, summary formatting. Suite at 82 tests; verified end-to-end against a ClimaCoupler AMIP run (component switches, benchmarks, summary) via a live-browser drive test.

## Left for a follow-up
- [ ] Read ocean and seaice diagnostics (the example AMIP run has none to test against)

<img width="2435" height="1282" alt="image" src="https://github.com/user-attachments/assets/d76bb97e-3bde-4969-819e-33118281a8a1" />
